### PR TITLE
fix(install): ensure updated Bash version is installed via Homebrew

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ install_dependencies() {
 
     # Install other dependencies
     # other_dependencies=("curl" "gawk" "git" "vim" "cmake" "pkg-config" "freetype" "fontconfig" "xcb-util-xrm" "xkbcommon" "python3" "jp2a")
-    other_dependencies=("curl" "gawk" "git" "vim" "cmake" "pkg-config" "freetype" "fontconfig" "python3" "jp2a")
+    other_dependencies=("bash" "curl" "gawk" "git" "vim" "cmake" "pkg-config" "freetype" "fontconfig" "python3" "jp2a")
 
     echo "Installing other dependencies: ${other_dependencies[*]}"
     for dependency in "${other_dependencies[@]}"; do


### PR DESCRIPTION
- Added `bash` to the list of dependencies to ensure the latest version is installed.
- This is required for compatibility with the Mate project.
- Prevents issues caused by the outdated macOS system Bash (3.x).