### PR TITLE
feat(docker): update Dockerfile.test and add build script

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,6 @@
 # Build and run:
-#   docker build --build-arg DEV_USER_NAME=$USER --build-arg=DEV_USER_PWD=1234 --build-arg DEV_UID=$(id -u) --build-arg DOMAINUSERS_GID=$(id -g) --rm -t dotfiles:test -f Dockerfile.test docker
-#   docker build --build-arg DEV_USER_NAME=$USER --build-arg=DEV_USER_PWD=1234 --build-arg DEV_UID=$(id -u) --build-arg DOMAINUSERS_GID=$(id -g) --rm -t dotfiles:latest -f Dockerfile docker
+#   docker build --build-arg DEV_HOME=$HOME --build-arg DEV_USER_NAME=$USER --build-arg=DEV_USER_PWD=1234 --build-arg DEV_UID=$(id -u) --build-arg DOMAINUSERS_GID=$(id -g) --rm -t dotfiles:test -f Dockerfile.test docker
+#   docker build --build-arg DEV_HOME=$HOME --build-arg DEV_USER_NAME=$USER --build-arg=DEV_USER_PWD=1234 --build-arg DEV_UID=$(id -u) --build-arg DOMAINUSERS_GID=$(id -g) --rm -t dotfiles:latest -f Dockerfile docker
 #
 # ssh credentials (test user):
 #   ssh -t -p 3000 $USER@localhost "bash --login"
@@ -9,15 +9,15 @@
 FROM ubuntu:22.04
 
 # Update package lists and install SSH server
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y sudo zsh \
+RUN apt-get update && apt-get upgrade -y                    \
+    && apt-get install -y sudo                              \
     && apt-get clean
 
 ARG DEV_USER_NAME=dev
 ARG DEV_USER_PWD=1234
-ARG DEV_UID=365439264
-ARG DOMAINUSERS_GID=2130182657
-ARG DEV_HOME=/lhome/${DEV_USER_NAME}
+ARG DEV_UID=1003
+ARG DOMAINUSERS_GID=1003
+ARG DEV_HOME=/home/${DEV_USER_NAME}
 
 ENV ROOT_PWD=1234
 
@@ -30,6 +30,15 @@ RUN if ! getent group ${DOMAINUSERS_GID}; then \
     && useradd -m -d ${DEV_HOME} ${DEV_USER_NAME} -u ${DEV_UID} -g ${EXISTING_GROUP:-domainusers} \
     && usermod -a -G sudo ${DEV_USER_NAME} \
     && yes ${DEV_USER_PWD} | passwd ${DEV_USER_NAME} \
-    && echo 'root:'${ROOT_PWD} | chpasswd
+    && echo 'root:'${ROOT_PWD} | chpasswd; \
+    # allow sudo for group 'sudo' (no password in containers)
+    printf '%%sudo ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/99-sudo; \
+    chmod 0440 /etc/sudoers.d/99-sudo
 
 RUN usermod -s /bin/bash ${DEV_USER_NAME}
+
+ENV PATH="${ASDF_DATA_DIR:-$DEV_HOME/.asdf}/shims:${DEV_HOME}/.local/bin:${PATH}"
+
+USER ${DEV_USER_NAME}
+RUN mkdir -p ${DEV_HOME}/.local/bin
+

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+IMAGE_NAME="dotfiles:test"
+DOCKERFILE="Dockerfile.test"
+
+echo docker build                               
+echo "   --build-arg DEV_HOME=$HOME"
+echo "   --build-arg DEV_USER_NAME=$(id -un)"
+echo "   --build-arg DEV_USER_PWD=1234"
+echo "   --build-arg DEV_UID=$(id -u)"
+echo "   --build-arg DOMAINUSERS_GID=$(id -g)"
+echo "   --rm -t $IMAGE_NAME -f $DOCKERFILE docker"
+docker build                                    \
+    --build-arg DEV_HOME="$HOME"                \
+    --build-arg DEV_USER_NAME="$(id -un)"       \
+    --build-arg DEV_USER_PWD=1234               \
+    --build-arg DEV_UID="$(id -u)"              \
+    --build-arg DOMAINUSERS_GID="$(id -g)"      \
+    --rm -t $IMAGE_NAME -f $DOCKERFILE docker


### PR DESCRIPTION
## Summary
- Add `DEV_HOME` build arg; update default UID/GID values for local dev
- Remove hard-coded corporate `/lhome` path; use `/home` as default
- Add passwordless sudo for the `sudo` group inside the container
- Set up asdf shims and `.local/bin` on `PATH`
- Switch to user context for subsequent `RUN` steps
- Add `build-docker.sh` helper script to simplify image build invocation

## Why
Previous defaults were tied to a corporate environment. This makes the Dockerfile usable for local development out of the box.