### PR TITLE
feat: implement manifest-driven sanity test suite

### DIFF
--- a/helpers/read-manifest.py
+++ b/helpers/read-manifest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Read values from manifest.toml and output them for shell consumption.
+
+Usage:
+  ./helpers/read-manifest.py packages.linux.list          # one item per line
+  ./helpers/read-manifest.py cargo.tools                   # one item per line
+  ./helpers/read-manifest.py symlinks --format jsonl       # one JSON object per line
+  ./helpers/read-manifest.py resources --format jsonl      # one JSON object per line
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    print("Error: Python 3.11+ required (for tomllib).", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_manifest(script_path):
+    """Find manifest.toml relative to this script (repo_root/helpers/read-manifest.py)."""
+    repo_root = script_path.resolve().parent.parent
+    manifest = repo_root / "manifest.toml"
+    if manifest.exists():
+        return manifest
+    raise FileNotFoundError(f"manifest.toml not found at {manifest}")
+
+
+def get_nested(data, key_path):
+    """Navigate nested dict using dot notation: 'packages.linux.list'."""
+    keys = key_path.split(".")
+    current = data
+    for key in keys:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            print(f"Error: key '{key_path}' not found in manifest.toml", file=sys.stderr)
+            sys.exit(1)
+    return current
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read manifest.toml values")
+    parser.add_argument("key", help="Dot-separated key path (e.g., packages.linux.list)")
+    parser.add_argument(
+        "--format",
+        choices=["plain", "jsonl"],
+        default="plain",
+        help="Output format (default: plain)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Path to manifest.toml (auto-detected if omitted)",
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest or find_manifest(Path(__file__))
+
+    with open(manifest_path, "rb") as f:
+        data = tomllib.load(f)
+
+    value = get_nested(data, args.key)
+
+    if args.format == "jsonl":
+        if isinstance(value, list):
+            for item in value:
+                print(json.dumps(item))
+        else:
+            print(json.dumps(value))
+    else:
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    print(json.dumps(item))
+                else:
+                    print(item)
+        elif isinstance(value, dict):
+            print(json.dumps(value))
+        else:
+            print(value)
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/read-manifest.py
+++ b/helpers/read-manifest.py
@@ -42,14 +42,41 @@ def get_nested(data, key_path):
     return current
 
 
+def _parse_field_specs(spec_str):
+    """Parse 'name,type:symlink,backup:true' into [(field, default_or_None), ...]."""
+    specs = []
+    for token in spec_str.split(","):
+        if ":" in token:
+            field, default = token.split(":", 1)
+        else:
+            field, default = token, None
+        specs.append((field.strip(), default))
+    return specs
+
+
+def _get_field_value(item, field, default):
+    """Get a field from a dict, converting booleans to 'true'/'false'."""
+    if field not in item:
+        return default if default is not None else ""
+    val = item[field]
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    return str(val)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Read manifest.toml values")
     parser.add_argument("key", help="Dot-separated key path (e.g., packages.linux.list)")
     parser.add_argument(
         "--format",
-        choices=["plain", "jsonl"],
+        choices=["plain", "jsonl", "tsv"],
         default="plain",
         help="Output format (default: plain)",
+    )
+    parser.add_argument(
+        "--fields",
+        default=None,
+        help="Comma-separated fields for --format tsv: 'field' or 'field:default'",
     )
     parser.add_argument(
         "--manifest",
@@ -72,6 +99,17 @@ def main():
                 print(json.dumps(item))
         else:
             print(json.dumps(value))
+    elif args.format == "tsv":
+        if not args.fields:
+            print("Error: --fields is required with --format tsv", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(value, list):
+            print("Error: --format tsv only supports list values", file=sys.stderr)
+            sys.exit(1)
+        field_specs = _parse_field_specs(args.fields)
+        for item in value:
+            parts = [_get_field_value(item, f, d) for f, d in field_specs]
+            print("\t".join(parts))
     else:
         if isinstance(value, list):
             for item in value:

--- a/helpers/shell-utils.sh
+++ b/helpers/shell-utils.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Shared shell utilities sourced by install.sh and tests/helpers.sh.
+
+resolve_path() {
+    # Portable readlink -f: works on both Linux (GNU) and macOS ARM (BSD).
+    # Falls back to Python when GNU coreutils are unavailable.
+    readlink -f "$1" 2>/dev/null \
+        || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,8 @@ function create_backups() {
 
     # Expand ~ to $HOME
     tgt="${tgt/#\~/$HOME}"
+    # Resolve src relative to repo root (not $PWD)
+    if [[ "$src" != /* ]]; then src="$script_dir/$src"; fi
 
     # Ensure parent directory exists
     mkdir -p "$(dirname "$tgt")"

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,54 @@ install_sys_packages() {
   set +x
 }
 
+install_non_asdf_tools() {
+  "$script_dir/helpers/read-manifest.py" resources --format jsonl | while IFS= read -r line; do
+    name=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
+    rtype=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['type'])")
+    rpath=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])")
+    url=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
+    branch=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('branch','main'))")
+    shallow=$(printf '%s' "$line" | python3 -c "import sys,json; print('true' if json.load(sys.stdin).get('shallow', False) else 'false')")
+    post_install=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('post_install',''))")
+
+    # Expand ~ and resolve relative paths
+    rpath="${rpath/#\~/$HOME}"
+
+    case "$rtype" in
+      git-clone)
+        clone_args=""
+        if [ "$shallow" = "true" ]; then
+          clone_args="--depth 1"
+        fi
+
+        if [ ! -d "$rpath" ]; then
+          echo "Cloning $name..."
+          git clone $clone_args "$url" "$rpath"
+        else
+          echo "Updating $name..."
+          pushd "$rpath" > /dev/null 2>&1 || { echo "Failed to pushd $rpath"; continue; }
+          git fetch --all --prune
+          git pull --rebase origin "$branch"
+          popd > /dev/null 2>&1 || echo "Failed to popd"
+        fi
+
+        if [ -n "$post_install" ] && pushd "$rpath" > /dev/null 2>&1; then
+          echo "Running post-install for $name..."
+          $post_install
+          popd > /dev/null 2>&1 || echo "Failed to popd"
+        fi
+        ;;
+      file-download)
+        mkdir -p "$(dirname "$rpath")"
+        if [ ! -f "$rpath" ]; then
+          echo "Downloading $name..."
+          curl -o "$rpath" "$url"
+        fi
+        ;;
+    esac
+  done
+}
+
 install_dependencies() {
   yes="$1"
 
@@ -113,94 +161,7 @@ install_dependencies() {
     curl -fsSL https://starship.rs/install.sh | sh -s -- -y -b "${USER_LOCAL_BIN}/"
   fi
 
-  # TODO: enhance the installation process. It's in brute-force way now
-  if [ ! -d "${USER_GIT_DOWNLOADS}/tmux" ]; then
-    echo "Cloning tmux..."
-    git clone https://github.com/tmux/tmux.git "${USER_GIT_DOWNLOADS}/tmux"
-  else
-    echo "Updating tmux repository..."
-    pushd "${USER_GIT_DOWNLOADS}/tmux" > /dev/null 2>&1 || echo "Failed to pushd .tmux"
-    git fetch --all --prune
-    git pull --rebase origin master
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if [ -d "${USER_GIT_DOWNLOADS}/tmux" ]; then
-    if [ ! -d "~/.tmux/plugins/tpm" ]; then
-      git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-    else
-      echo "Updating tmux tpm repository..."
-      pushd "~/.tmux/plugins/tpm" > /dev/null 2>&1 || echo "Failed to pushd .tmux/plugins/tpm"
-      git fetch --all --prune
-      git pull --rebase origin master
-      popd > /dev/null 2>&1 || echo "Failed to popd"
-    fi
-    echo "Building tmux..."
-    pushd "${USER_GIT_DOWNLOADS}/tmux" > /dev/null 2>&1 || echo "Failed to pushd ${USER_GIT_DOWNLOADS}/tmux"
-    sh autogen.sh
-    local enable_utf8_proc=""
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      enable_utf8_proc="--enable-utf8proc"
-    fi
-    # Get the number of CPUs, subtract 2, and ensure it's at least 1
-    cpu_count=$(( $(get_cpu_count) - 2 ))
-    if (( cpu_count < 1 )); then
-        cpu_count=1
-    fi
-    ./configure --prefix="${USER_LOCAL_HOME}" "$enable_utf8_proc" \
-      && make -j$cpu_count \
-      && make install
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if [ ! -d "${USER_GIT_DOWNLOADS}/fzf" ]; then
-    echo "Installing fzf..."
-    git clone --depth 1 https://github.com/junegunn/fzf.git "${USER_GIT_DOWNLOADS}/fzf"
-  else
-    echo "Updating fzf repository..."
-    pushd "${USER_GIT_DOWNLOADS}/fzf" > /dev/null 2>&1 || echo "Failed to pushd .fzf"
-    git fetch --all --prune
-    git pull --rebase origin master
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if pushd "${USER_GIT_DOWNLOADS}/fzf" ; then
-    ./install --all --xdg --completion --no-bash --no-zsh --no-fish --no-update-rc
-    ln -sf "$(readlink -f bin)"/* "${HOME}/.local/bin/"
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if [ ! -d "${USER_GIT_DOWNLOADS}/nerd-fonts" ]; then
-    echo "Cloning nerd-fonts..."
-    git clone --depth 1 https://github.com/ryanoasis/nerd-fonts.git ${USER_GIT_DOWNLOADS}/nerd-fonts
-  else
-    echo "Updating nerd-fonts repository..."
-    pushd "${USER_GIT_DOWNLOADS}/nerd-fonts" > /dev/null 2>&1 || echo "Failed to pushd ${USER_GIT_DOWNLOADS}/nerd-fonts"
-    git fetch --all --prune
-    git pull --rebase origin master
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if pushd "${USER_GIT_DOWNLOADS}/nerd-fonts" ; then
-    ./install.sh
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if [ ! -d "${USER_GIT_DOWNLOADS}/mate" ]; then
-    echo "Cloning mate..."
-    git clone --depth 1 https://github.com/jeffujioka/mate.git ${USER_GIT_DOWNLOADS}/mate
-  else
-    echo "Updating mate repository..."
-    pushd "${USER_GIT_DOWNLOADS}/mate" > /dev/null 2>&1 || echo "Failed to pushd ${USER_GIT_DOWNLOADS}/mate"
-    git fetch --all --prune
-    git pull --rebase origin master
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
-
-  if pushd "${USER_GIT_DOWNLOADS}/mate" ; then
-    ./install.sh
-    popd > /dev/null 2>&1 || echo "Failed to popd"
-  fi
+  install_non_asdf_tools
 }
 
 function backup_this() {

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,6 @@ USER_GIT_DOWNLOADS=".git_downloads"
 
 mkdir -p "${XDG_CONFIG_HOME}"
 mkdir -p "${USER_LOCAL_BIN}"
-mkdir -p "${HOME}/.zsh_completion.d"
 
 get_system_package_list() {
   if [[ "$OSTYPE" == darwin* ]]; then
@@ -117,6 +116,8 @@ install_dependencies() {
     echo "Installing Rust..."
     export RUSTUP_HOME=${XDG_CONFIG_HOME}/rustup
     export CARGO_HOME=${XDG_CONFIG_HOME}/cargo
+    export TMPDIR=${XDG_CONFIG_HOME}/tmp
+    mkdir -p "$TMPDIR"
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
     
     source "${XDG_CONFIG_HOME}/cargo/env"
@@ -127,6 +128,8 @@ install_dependencies() {
   rustup default stable
 
   echo "Installing Rust-based tools..."
+  export TMPDIR=${XDG_CONFIG_HOME}/tmp
+  mkdir -p "$TMPDIR"
   "$script_dir/helpers/read-manifest.py" cargo.tools | while IFS= read -r tool; do
     if command -v "$tool" > /dev/null 2>&1; then
       echo "'$tool' is already installed."

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 timestamp=$(date +%F_%H%M%S)
 
@@ -27,6 +28,10 @@ get_system_package_list() {
 
 # shellcheck source=helpers/shell-utils.sh
 . "$(dirname "$(readlink -f "$0")")/helpers/shell-utils.sh"
+
+# Validate manifest.toml before doing any destructive work.
+"$script_dir/helpers/read-manifest.py" cargo.tools --format tsv --fields "crate,binary:" > /dev/null \
+  || { echo "Error: manifest.toml is missing or invalid. Aborting."; exit 1; }
 
 install_sys_packages() {
   [ -n "${DEBUG:-}" ] && set -x
@@ -92,6 +97,7 @@ install_non_asdf_tools() {
 
         if [ -n "$post_install" ] && pushd "$rpath" > /dev/null 2>&1; then
           echo "Running post-install for $name..."
+          # Intentional: post_install is a trusted shell snippet from manifest.toml
           eval "$post_install"
           popd > /dev/null 2>&1 || echo "Failed to popd"
         fi
@@ -130,19 +136,16 @@ install_dependencies() {
   echo "Installing Rust-based tools..."
   export TMPDIR=${XDG_CONFIG_HOME}/tmp
   mkdir -p "$TMPDIR"
-  "$script_dir/helpers/read-manifest.py" cargo.tools | while IFS= read -r tool; do
-    if command -v "$tool" > /dev/null 2>&1; then
-      echo "'$tool' is already installed."
+  "$script_dir/helpers/read-manifest.py" cargo.tools --format tsv --fields "crate,binary:" \
+    | while IFS=$'\t' read -r crate binary; do
+    binary="${binary:-$crate}"
+    if command -v "$binary" > /dev/null 2>&1; then
+      echo "'$binary' is already installed."
     else
-      echo "Installing $tool via cargo..."
-      cargo install "$tool"
+      echo "Installing $crate via cargo..."
+      cargo install --locked "$crate"
     fi
   done
-
-  if [ ! -f "${USER_LOCAL_BIN}/starship" ]; then
-    echo "Installing Starship..."
-    curl -fsSL https://starship.rs/install.sh | sh -s -- -y -b "${USER_LOCAL_BIN}/"
-  fi
 
   install_non_asdf_tools
 }

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,13 @@ get_system_package_list() {
   fi
 }
 
+resolve_path() {
+    # Portable readlink -f: works on both Linux (GNU) and macOS ARM (BSD).
+    # Falls back to Python when GNU coreutils are unavailable.
+    readlink -f "$1" 2>/dev/null \
+        || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}
+
 get_cpu_count() {
     if command -v nproc &>/dev/null; then
         # Use nproc if available (common on Linux)
@@ -221,39 +228,44 @@ function backup_this() {
 
 function create_backups() {
   mkdir -p "${bak_dir}"
-  
-  mkdir -p "${HOME}/.zsh_completion.d"
-  ln -sf "$(readlink -f zsh_completion.d)" "${HOME}/.zsh_completion.d"
-  
-  # backup_this "${HOME}/.bashrc"
-  # ln -sf "$(readlink -f bashrc)" "${HOME}/.bashrc"
-  
-  backup_this "${HOME}/.zshrc"
-  ln -sf "$(readlink -f zshrc)" "${HOME}/.zshrc"
-  
-  backup_this "${HOME}/.zsh_aliases"
-  ln -sf "$(readlink -f zsh_aliases)" "${HOME}/.zsh_aliases"
-  
-  backup_this "${HOME}/.zsh_completions"
-  ln -sf "$(readlink -f zsh_completions)" "${HOME}/.zsh_completions"
-  
-  backup_this "${HOME}/.zsh_aliases.d"
-  ln -sf "$(readlink -f zsh_aliases.d)" "${HOME}/"
 
-  ln -sf "$(readlink -f config/ascii-art-goku.txt)" "${XDG_CONFIG_HOME}/"
+  "$script_dir/helpers/read-manifest.py" symlinks --format jsonl | while IFS= read -r line; do
+    src=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['source'])")
+    tgt=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['target'])")
+    typ=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type','symlink'))")
+    should_backup=$(printf '%s' "$line" | python3 -c "import sys,json; print('true' if json.load(sys.stdin).get('backup', True) else 'false')")
 
-  backup_this "${XDG_CONFIG_HOME}/starship.toml"
-  ln -sf "$(readlink -f config/starship.toml)" "${XDG_CONFIG_HOME}/"
+    # Expand ~ to $HOME
+    tgt="${tgt/#\~/$HOME}"
 
-  backup_this "${XDG_CONFIG_HOME}/fzf/fzf.zsh"
-  ln -sf "$(readlink -f config/fzf.zsh)" "${XDG_CONFIG_HOME}/fzf/"
+    # Ensure parent directory exists
+    mkdir -p "$(dirname "$tgt")"
 
-  backup_this "${HOME}/.gitignore"
-  ln -sf "$(readlink -f gitignore)" "${HOME}/.gitignore"
+    case "$typ" in
+      symlink)
+        if [ "$should_backup" = "true" ]; then
+          backup_this "$tgt"
+        fi
+        ln -sf "$(resolve_path "$src")" "$tgt"
+        ;;
+      copy)
+        if [ "$should_backup" = "true" ]; then
+          backup_this "$tgt"
+        fi
+        cp "$src" "$tgt"
+        ;;
+      glob)
+        for f in $src; do
+          tgt_dir="${tgt%/\*}"
+          tgt_dir="${tgt_dir/#\~/$HOME}"
+          mkdir -p "$tgt_dir"
+          ln -sf "$(resolve_path "$f")" "$tgt_dir/"
+        done
+        ;;
+    esac
+  done
 
-  backup_this "${HOME}/.gitconfig"
-  cp gitconfig "${HOME}/.gitconfig"
-  # ln -sf "$(readlink -f gitconfig)" "${HOME}/.gitconfig"
+  # gitconfig special handling: set user name/email after copy
   if [ -n "$GIT_USER_NAME" ]; then
     echo "setting git user.name to $GIT_USER_NAME"
     git config --global user.name "$GIT_USER_NAME"
@@ -262,14 +274,6 @@ function create_backups() {
     echo "setting git user.email to $GIT_USER_EMAIL"
     git config --global user.email "$GIT_USER_EMAIL"
   fi
-
-  backup_this "${HOME}/.tmux.conf"
-  ln -sf "$(readlink -f tmux.conf)" "${HOME}/.tmux.conf"
-
-  backup_this "${HOME}/.vimrc"
-  ln -sf "$(readlink -f vimrc)" "${HOME}/.vimrc"
-
-  ln -sf "$(readlink -f bin)/*" "${USER_LOCAL_BIN}/"
 }
 
 function check_config_properties() {

--- a/install.sh
+++ b/install.sh
@@ -70,28 +70,23 @@ install_sys_packages() {
 }
 
 install_non_asdf_tools() {
-  "$script_dir/helpers/read-manifest.py" resources --format jsonl | while IFS= read -r line; do
-    name=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
-    rtype=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['type'])")
-    rpath=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])")
-    url=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
-    branch=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('branch','main'))")
-    shallow=$(printf '%s' "$line" | python3 -c "import sys,json; print('true' if json.load(sys.stdin).get('shallow', False) else 'false')")
-    post_install=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('post_install',''))")
+  "$script_dir/helpers/read-manifest.py" resources --format tsv \
+      --fields "name,type,path,url,branch:main,shallow:false,post_install:" \
+      | while IFS=$'\t' read -r name rtype rpath url branch shallow post_install; do
 
-    # Expand ~ and resolve relative paths
+    # Expand ~ to $HOME
     rpath="${rpath/#\~/$HOME}"
 
     case "$rtype" in
       git-clone)
-        clone_args=""
+        local clone_args=()
         if [ "$shallow" = "true" ]; then
-          clone_args="--depth 1"
+          clone_args+=(--depth 1)
         fi
 
         if [ ! -d "$rpath" ]; then
           echo "Cloning $name..."
-          git clone $clone_args "$url" "$rpath"
+          git clone "${clone_args[@]}" "$url" "$rpath"
         else
           echo "Updating $name..."
           pushd "$rpath" > /dev/null 2>&1 || { echo "Failed to pushd $rpath"; continue; }
@@ -179,15 +174,13 @@ function backup_this() {
 function create_backups() {
   mkdir -p "${bak_dir}"
 
-  "$script_dir/helpers/read-manifest.py" symlinks --format jsonl | while IFS= read -r line; do
-    src=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['source'])")
-    tgt=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['target'])")
-    typ=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type','symlink'))")
-    should_backup=$(printf '%s' "$line" | python3 -c "import sys,json; print('true' if json.load(sys.stdin).get('backup', True) else 'false')")
+  "$script_dir/helpers/read-manifest.py" symlinks --format tsv \
+      --fields "source,target,type:symlink,backup:true" \
+      | while IFS=$'\t' read -r src tgt typ should_backup; do
 
     # Expand ~ to $HOME
     tgt="${tgt/#\~/$HOME}"
-    # Resolve src relative to repo root (not $PWD)
+    # Resolve src relative to repo root (not $PWD) — C2 fix
     if [[ "$src" != /* ]]; then src="$script_dir/$src"; fi
 
     # Ensure parent directory exists

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ install_non_asdf_tools() {
 
         if [ -n "$post_install" ] && pushd "$rpath" > /dev/null 2>&1; then
           echo "Running post-install for $name..."
-          $post_install
+          eval "$post_install"
           popd > /dev/null 2>&1 || echo "Failed to popd"
         fi
         ;;

--- a/install.sh
+++ b/install.sh
@@ -118,9 +118,9 @@ install_non_asdf_tools() {
 }
 
 install_dependencies() {
-  yes="$1"
-
-  install_sys_packages
+  if [ -z "$no_sudo_install" ]; then
+    install_sys_packages
+  fi
 
   if ! command -v cargo > /dev/null 2>&1 ; then
     echo "Installing Rust..."
@@ -254,6 +254,7 @@ function check_config_properties() {
 }
 
 install_deps="1"
+no_sudo_install=""
 no_backups="1"
 install_all=""
 
@@ -263,6 +264,11 @@ do
     --no-install-deps)
       install_deps=""
       echo "it won't install deps!!!"
+      shift
+      ;;
+    --no-sudo-install)
+      no_sudo_install="1"
+      echo "skipping system package installation (no sudo)"
       shift
       ;;
     --no-backups)
@@ -283,7 +289,7 @@ done
 check_config_properties
 
 if [ -n "$install_deps" ]; then
-  if [ -z "${install_all}" ] ; then
+  if [ -z "${install_all}" ] && [ -z "$no_sudo_install" ]; then
     echo "This script will install the following additional packages:"
     echo '  automake
     autotools-dev

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ resolve_path() {
 }
 
 install_sys_packages() {
-  set -x
+  [ -n "${DEBUG:-}" ] && set -x
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if ! command -v brew &>/dev/null; then
       echo "homebrew is not installed."
@@ -66,7 +66,7 @@ install_sys_packages() {
     sleep 1
     sudo apt install -y $(get_system_package_list | tr '\n' ' ')
   fi
-  set +x
+  [ -n "${DEBUG:-}" ] && set +x
 }
 
 install_non_asdf_tools() {

--- a/install.sh
+++ b/install.sh
@@ -33,19 +33,6 @@ resolve_path() {
         || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
 }
 
-get_cpu_count() {
-    if command -v nproc &>/dev/null; then
-        # Use nproc if available (common on Linux)
-        nproc
-    elif sysctl -n hw.logicalcpu &>/dev/null || sysctl -n hw.ncpu &>/dev/null ; then
-        # Use sysctl for systems where it's available (e.g., macOS/ARM)
-        sysctl -n hw.logicalcpu 2>/dev/null || sysctl -n hw.ncpu
-    else
-        # Fallback to checking /proc/cpuinfo (Linux systems)
-        echo "10"
-    fi
-}
-
 install_sys_packages() {
   set -x
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -135,11 +122,6 @@ install_dependencies() {
 
   install_sys_packages
 
-  if [ ! -f "${HOME}/.zsh_completion.d/tmux_completion" ]; then
-    echo "Installing tmux completion..."
-    curl -o "${HOME}/.zsh_completion.d/tmux_completion" https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux
-  fi
-
   if ! command -v cargo > /dev/null 2>&1 ; then
     echo "Installing Rust..."
     export RUSTUP_HOME=${XDG_CONFIG_HOME}/rustup
@@ -154,7 +136,14 @@ install_dependencies() {
   rustup default stable
 
   echo "Installing Rust-based tools..."
-  cargo install procs du-dust zoxide ripgrep fd-find bat exa viu --locked
+  "$script_dir/helpers/read-manifest.py" cargo.tools | while IFS= read -r tool; do
+    if command -v "$tool" > /dev/null 2>&1; then
+      echo "'$tool' is already installed."
+    else
+      echo "Installing $tool via cargo..."
+      cargo install "$tool"
+    fi
+  done
 
   if [ ! -f "${USER_LOCAL_BIN}/starship" ]; then
     echo "Installing Starship..."

--- a/install.sh
+++ b/install.sh
@@ -26,12 +26,8 @@ get_system_package_list() {
   fi
 }
 
-resolve_path() {
-    # Portable readlink -f: works on both Linux (GNU) and macOS ARM (BSD).
-    # Falls back to Python when GNU coreutils are unavailable.
-    readlink -f "$1" 2>/dev/null \
-        || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-}
+# shellcheck source=helpers/shell-utils.sh
+. "$(dirname "$(readlink -f "$0")")/helpers/shell-utils.sh"
 
 install_sys_packages() {
   [ -n "${DEBUG:-}" ] && set -x

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,14 @@ mkdir -p "${XDG_CONFIG_HOME}"
 mkdir -p "${USER_LOCAL_BIN}"
 mkdir -p "${HOME}/.bash_completion.d"
 
+get_system_package_list() {
+  if [[ "$OSTYPE" == darwin* ]]; then
+    "$script_dir/helpers/read-manifest.py" packages.darwin.list
+  elif [[ "$OSTYPE" == linux* ]]; then
+    "$script_dir/helpers/read-manifest.py" packages.linux.list
+  fi
+}
+
 get_cpu_count() {
     if command -v nproc &>/dev/null; then
         # Use nproc if available (common on Linux)
@@ -31,60 +39,46 @@ get_cpu_count() {
     fi
 }
 
-install_dependencies() {
-  yes="$1"
-
+install_sys_packages() {
+  set -x
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Running on macOS. Using brew for dependency installation."
+    if ! command -v brew &>/dev/null; then
+      echo "homebrew is not installed."
+      echo "trying to install it."
+      sleep 1
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      echo >> "$HOME/.zprofile"
+      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
 
-    # Update Homebrew
-    echo "Updating Homebrew..."
+    echo ""
+    sleep 1
     brew update && brew upgrade
 
-    # Install tmux dependencies
-    tmux_dependencies=("libevent" "ncurses" "automake" "bison" "byacc" "utf8proc")
-
-    echo "Installing tmux dependencies: ${tmux_dependencies[*]}"
-    for dependency in "${tmux_dependencies[@]}"; do
-      echo "Installing ${dependency}..."
-      brew install "${dependency}"
-    done
-
-    # Install other dependencies
-    # other_dependencies=("curl" "gawk" "git" "vim" "cmake" "pkg-config" "freetype" "fontconfig" "xcb-util-xrm" "xkbcommon" "python3" "jp2a")
-    other_dependencies=("bash" "curl" "gawk" "git" "vim" "cmake" "pkg-config" "freetype" "fontconfig" "python3" "jp2a")
-
-    echo "Installing other dependencies: ${other_dependencies[*]}"
-    for dependency in "${other_dependencies[@]}"; do
-      echo "Installing ${dependency}..."
-      brew install "${dependency}"
+    echo "Installing packages:"
+    get_system_package_list | while IFS= read -r package; do
+      echo "Installing ${package}..."
+      brew install "${package}"
     done
 
   else
-    echo "Running on Linux. Using apt for dependency installation."
+    echo ""
+    sleep 1
+    sudo apt update && sudo apt upgrade -y
 
-    echo "sudo apt update && sudo apt upgrade ${yes}"
-    sudo apt update && sudo apt upgrade "${yes}"
-
-    tmux_dependencies="libevent-dev libncurses-dev autotools-dev automake bison byacc"
-    echo "sudo apt install ${yes} ${tmux_dependencies}"
-    sudo apt install "${yes}" ${tmux_dependencies}
-
-    sudo apt install "${yes}" \
-      curl \
-      gawk \
-      git \
-      vim \
-      cmake \
-      pkg-config \
-      libfreetype6-dev \
-      libfontconfig1-dev \
-      libxcb-xfixes0-dev \
-      libxkbcommon-dev \
-      python3 \
-      jp2a \
-      xsel
+    echo ""
+    echo "Installing packages:"
+    sleep 1
+    sudo apt install -y $(get_system_package_list | tr '\n' ' ')
   fi
+  set +x
+}
+
+install_dependencies() {
+  yes="$1"
+
+  install_sys_packages
 
   if [ ! -f "${HOME}/.bash_completion.d/tmux_completion" ]; then
     echo "Installing tmux completion..."

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ USER_GIT_DOWNLOADS=".git_downloads"
 
 mkdir -p "${XDG_CONFIG_HOME}"
 mkdir -p "${USER_LOCAL_BIN}"
-mkdir -p "${HOME}/.bash_completion.d"
+mkdir -p "${HOME}/.zsh_completion.d"
 
 get_system_package_list() {
   if [[ "$OSTYPE" == darwin* ]]; then
@@ -135,9 +135,9 @@ install_dependencies() {
 
   install_sys_packages
 
-  if [ ! -f "${HOME}/.bash_completion.d/tmux_completion" ]; then
+  if [ ! -f "${HOME}/.zsh_completion.d/tmux_completion" ]; then
     echo "Installing tmux completion..."
-    curl -o "${HOME}/.bash_completion.d/tmux_completion" https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux
+    curl -o "${HOME}/.zsh_completion.d/tmux_completion" https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux
   fi
 
   if ! command -v cargo > /dev/null 2>&1 ; then

--- a/install.sh
+++ b/install.sh
@@ -293,24 +293,7 @@ check_config_properties
 if [ -n "$install_deps" ]; then
   if [ -z "${install_all}" ] && [ -z "$no_sudo_install" ]; then
     echo "This script will install the following additional packages:"
-    echo '  automake
-    autotools-dev
-    bison
-    byacc
-    cmake
-    curl
-    gawk
-    git
-    jp2a
-    libevent-dev
-    libfontconfig1-dev
-    libfreetype6-dev
-    libncurses-dev
-    libxcb-xfixes0-dev
-    libxkbcommon-dev
-    pkg-config
-    python3
-    vim'
+    get_system_package_list | sed 's/^/  /'
     read -rp "Do you want to continue? [Y/n] " response
 
     response=$(echo "$response" | tr '[:upper:]' '[:lower:]')

--- a/install.sh
+++ b/install.sh
@@ -302,7 +302,7 @@ if [ -n "$install_deps" ]; then
       exit 1
     fi
   fi
-  install_dependencies "${install_all}"
+  install_dependencies
 fi
 
 if [ -n "$no_backups" ]; then

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ function backup_this() {
   mv "${file}" "${bak_dir}/${bak_name}"
 }
 
-function create_backups() {
+function apply_dotfiles() {
   mkdir -p "${bak_dir}"
 
   "$script_dir/helpers/read-manifest.py" symlinks --format tsv \
@@ -299,7 +299,7 @@ if [ -n "$install_deps" ]; then
 fi
 
 if [ -n "$no_backups" ]; then
-  create_backups
+  apply_dotfiles
 fi
 
 echo ""

--- a/manifest.toml
+++ b/manifest.toml
@@ -46,9 +46,35 @@ list = [
   "zsh",
 ]
 
-[cargo]
-# Installed via: cargo install <tool>
-tools = ["eza", "zoxide"]
+[[cargo.tools]]
+crate = "bat"
+
+[[cargo.tools]]
+crate = "du-dust"
+binary = "dust"
+
+[[cargo.tools]]
+crate = "eza"
+
+[[cargo.tools]]
+crate = "fd-find"
+binary = "fd"
+
+[[cargo.tools]]
+crate = "procs"
+
+[[cargo.tools]]
+crate = "ripgrep"
+binary = "rg"
+
+[[cargo.tools]]
+crate = "starship"
+
+[[cargo.tools]]
+crate = "viu"
+
+[[cargo.tools]]
+crate = "zoxide"
 
 [[resources]]
 name = "tpm"

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,0 +1,138 @@
+# manifest.toml — Single source of truth for all installed packages,
+# tools, symlinks, and resources.
+#
+# Consumed by: install.sh, install-asdf-plugins.sh, test.sh, tests/*.sh
+# Parsed via:  helpers/read-manifest.py (Python 3.11+ tomllib)
+
+[packages.linux]
+# Installed via: sudo apt install
+list = [
+  "autoconf",
+  "bison",
+  "build-essential",
+  "curl",
+  "gawk",
+  "gcc",
+  "git",
+  "jp2a",
+  "libevent-dev",
+  "libfontconfig1-dev",
+  "libfreetype6-dev",
+  "libncurses-dev",
+  "make",
+  "pkg-config",
+  "python3",
+  "xsel",
+  "zsh",
+]
+
+[packages.darwin]
+# Installed via: brew install
+list = [
+  "autoconf",
+  "curl",
+  "fontconfig",
+  "freetype",
+  "gawk",
+  "gcc",
+  "git",
+  "jp2a",
+  "libevent",
+  "make",
+  "ncurses",
+  "pkg-config",
+  "python3",
+  "utf8proc",
+  "zsh",
+]
+
+[cargo]
+# Installed via: cargo install <tool>
+tools = ["eza", "zoxide"]
+
+[[resources]]
+name = "tpm"
+type = "git-clone"
+path = "~/.tmux/plugins/tpm"
+url = "https://github.com/tmux-plugins/tpm"
+branch = "master"
+
+[[resources]]
+name = "nerd-fonts"
+type = "git-clone"
+path = ".git_downloads/nerd-fonts"
+url = "https://github.com/ryanoasis/nerd-fonts"
+branch = "master"
+shallow = true
+post_install = "./install.sh"
+
+[[resources]]
+name = "mate"
+type = "git-clone"
+path = ".git_downloads/mate"
+url = "https://github.com/jeffujioka/mate"
+branch = "main"
+shallow = true
+post_install = "./install.sh"
+
+[[resources]]
+name = "tmux-completion"
+type = "file-download"
+path = "~/.bash_completion.d/tmux_completion"
+url = "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux"
+
+[[symlinks]]
+source = "zshrc"
+target = "~/.zshrc"
+
+[[symlinks]]
+source = "zsh_aliases"
+target = "~/.zsh_aliases"
+
+[[symlinks]]
+source = "zsh_completions"
+target = "~/.zsh_completions"
+
+[[symlinks]]
+source = "zsh_aliases.d"
+target = "~/.zsh_aliases.d"
+
+[[symlinks]]
+source = "zsh_completion.d"
+target = "~/.zsh_completion.d"
+backup = false
+
+[[symlinks]]
+source = "config/starship.toml"
+target = "~/.config/starship.toml"
+
+[[symlinks]]
+source = "config/fzf.zsh"
+target = "~/.config/fzf/fzf.zsh"
+
+[[symlinks]]
+source = "config/ascii-art-goku.txt"
+target = "~/.config/ascii-art-goku.txt"
+backup = false
+
+[[symlinks]]
+source = "gitignore"
+target = "~/.gitignore"
+
+[[symlinks]]
+source = "tmux.conf"
+target = "~/.tmux.conf"
+
+[[symlinks]]
+source = "vimrc"
+target = "~/.vimrc"
+
+[[symlinks]]
+source = "gitconfig"
+target = "~/.gitconfig"
+type = "copy"
+
+[[symlinks]]
+source = "bin/*"
+target = "~/.local/bin/*"
+type = "glob"

--- a/manifest.toml
+++ b/manifest.toml
@@ -78,7 +78,7 @@ post_install = "./install.sh"
 [[resources]]
 name = "tmux-completion"
 type = "file-download"
-path = "~/.bash_completion.d/tmux_completion"
+path = "~/.zsh_completion.d/tmux_completion"
 url = "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux"
 
 [[symlinks]]

--- a/manifest.toml
+++ b/manifest.toml
@@ -17,7 +17,7 @@ list = [
   "jp2a",
   "libevent-dev",
   "libfontconfig1-dev",
-  "libfreetype6-dev",
+  "libfreetype-dev",
   "libncurses-dev",
   "make",
   "pkg-config",
@@ -74,12 +74,6 @@ url = "https://github.com/jeffujioka/mate"
 branch = "main"
 shallow = true
 post_install = "./install.sh"
-
-[[resources]]
-name = "tmux-completion"
-type = "file-download"
-path = "~/.zsh_completion.d/tmux_completion"
-url = "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux"
 
 [[symlinks]]
 source = "zshrc"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# CLI entry point for all testing operations.
+#
+# Usage:
+#   ./test.sh build-image <sudo|no-sudo|all>
+#   ./test.sh sanity-check [--docker] <sudo|no-sudo|all>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./test.sh build-image <sudo|no-sudo|all>
+  ./test.sh sanity-check [--docker] <sudo|no-sudo|all>
+
+Commands:
+  build-image     Build Docker test images
+  sanity-check    Run sanity checks against the installation
+
+Flags (sanity-check):
+  --docker        Run inside Docker containers (default: run locally)
+
+Targets:
+  sudo            Full install / system packages checked
+  no-sudo         No-sudo install / skip system package checks
+  all             (default) Both scenarios
+EOF
+    exit 1
+}
+
+# ── build-image ──────────────────────────────────────────────────────
+
+cmd_build_image() {
+    local target="${1:-all}"
+    case "$target" in
+        sudo)
+            echo "Building dotfiles-test-sudo..."
+            docker build -t dotfiles-test-sudo \
+                -f "$SCRIPT_DIR/tests/docker/Dockerfile.sudo" \
+                "$SCRIPT_DIR/tests/docker"
+            ;;
+        no-sudo)
+            echo "Building dotfiles-test-no-sudo..."
+            docker build -t dotfiles-test-no-sudo \
+                -f "$SCRIPT_DIR/tests/docker/Dockerfile.no-sudo" \
+                "$SCRIPT_DIR"
+            ;;
+        all)
+            cmd_build_image sudo
+            cmd_build_image no-sudo
+            ;;
+        *)
+            echo "Error: invalid target '$target' (use: sudo, no-sudo, all)"
+            exit 1
+            ;;
+    esac
+}
+
+# ── sanity-check (local) ────────────────────────────────────────────
+
+run_local_checks() {
+    local target="${1:-all}"
+    local rc=0
+
+    export SANITY_COUNTERS_FILE
+    SANITY_COUNTERS_FILE=$(mktemp)
+    printf '0 0 0' > "$SANITY_COUNTERS_FILE"
+
+    if [ "$target" != "no-sudo" ]; then
+        "$SCRIPT_DIR/tests/check-system-packages.sh" || rc=1
+    fi
+
+    "$SCRIPT_DIR/tests/check-asdf-tools.sh"     || rc=1
+    "$SCRIPT_DIR/tests/check-cargo-tools.sh"     || rc=1
+    "$SCRIPT_DIR/tests/check-non-asdf-tools.sh"  || rc=1
+    "$SCRIPT_DIR/tests/check-symlinks.sh"        || rc=1
+
+    . "$SCRIPT_DIR/tests/helpers.sh"
+    summary || rc=1
+
+    rm -f "$SANITY_COUNTERS_FILE"
+    return "$rc"
+}
+
+# ── sanity-check (docker) ───────────────────────────────────────────
+
+run_docker_scenario() {
+    local scenario="$1"
+    local image="dotfiles-test-$scenario"
+    local install_flags=""
+    local check_target="$scenario"
+
+    if [ "$scenario" = "no-sudo" ]; then
+        install_flags="--no-sudo-install"
+    fi
+
+    echo ""
+    echo "🐳 [$scenario] Running in Docker..."
+
+    if ! docker image inspect "$image" &>/dev/null; then
+        echo "Image '$image' not found. Building first..."
+        cmd_build_image "$scenario"
+    fi
+
+    docker run --rm \
+        -v "$SCRIPT_DIR:/home/testuser/.dotfiles:ro" \
+        --tmpfs /tmp \
+        "$image" \
+        bash -c "
+            cp -r /home/testuser/.dotfiles /home/testuser/dotfiles-work
+            cd /home/testuser/dotfiles-work
+            printf 'GIT_USER_NAME=\"Test User\"\nGIT_USER_EMAIL=\"test@test.com\"\n' > .config.properties
+            yes y | ./install.sh $install_flags || true
+            ./test.sh sanity-check $check_target
+        "
+}
+
+run_docker_checks() {
+    local target="${1:-all}"
+    local rc=0
+
+    case "$target" in
+        sudo)    run_docker_scenario sudo    || rc=1 ;;
+        no-sudo) run_docker_scenario no-sudo || rc=1 ;;
+        all)
+            run_docker_scenario sudo    || rc=1
+            run_docker_scenario no-sudo || rc=1
+            ;;
+        *)
+            echo "Error: invalid target '$target'"
+            exit 1
+            ;;
+    esac
+
+    return "$rc"
+}
+
+cmd_sanity_check() {
+    local docker_mode=false
+    local target="all"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --docker) docker_mode=true; shift ;;
+            sudo|no-sudo|all) target="$1"; shift ;;
+            *) echo "Error: unknown argument '$1'"; usage ;;
+        esac
+    done
+
+    if [ "$docker_mode" = true ]; then
+        run_docker_checks "$target"
+    else
+        run_local_checks "$target"
+    fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    build-image)   shift; cmd_build_image "$@" ;;
+    sanity-check)  shift; cmd_sanity_check "$@" ;;
+    *)             usage ;;
+esac

--- a/test.sh
+++ b/test.sh
@@ -69,6 +69,17 @@ run_local_checks() {
     trap 'rm -f "$SANITY_COUNTERS_FILE"' EXIT
     printf '0 0 0' > "$SANITY_COUNTERS_FILE"
 
+    # Source shell config to ensure PATH is set up correctly
+    # Try zshrc for zsh shells, bashrc for bash shells
+    if [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
+        source "$HOME/.zshrc" 2>/dev/null || true
+    elif [ -z "$ZSH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
+        source "$HOME/.bashrc" 2>/dev/null || true
+    fi
+    # Also ensure cargo is in PATH (for non-interactive shells)
+    CARGO_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/cargo"
+    [ -d "${CARGO_HOME}/bin" ] && export PATH="${CARGO_HOME}/bin:$PATH"
+
     if [ "$target" != "no-sudo" ]; then
         "$SCRIPT_DIR/tests/check-system-packages.sh" || rc=1
     fi

--- a/test.sh
+++ b/test.sh
@@ -66,6 +66,7 @@ run_local_checks() {
 
     export SANITY_COUNTERS_FILE
     SANITY_COUNTERS_FILE=$(mktemp)
+    trap 'rm -f "$SANITY_COUNTERS_FILE"' EXIT
     printf '0 0 0' > "$SANITY_COUNTERS_FILE"
 
     if [ "$target" != "no-sudo" ]; then
@@ -80,7 +81,6 @@ run_local_checks() {
     . "$SCRIPT_DIR/tests/helpers.sh"
     summary || rc=1
 
-    rm -f "$SANITY_COUNTERS_FILE"
     return "$rc"
 }
 

--- a/tests/check-asdf-tools.sh
+++ b/tests/check-asdf-tools.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Check that asdf tools from .tool-versions are installed with expected versions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/helpers.sh"
+
+section "asdf Tools"
+
+if ! command -v asdf &>/dev/null; then
+    fail "asdf not found"
+    exit 0
+fi
+
+asdf_ver=$(asdf version 2>/dev/null | sed 's/^v//')
+pass "asdf $asdf_ver"
+
+get_binary() {
+    case "$1" in
+        rust) echo "rustc" ;;
+        *)    echo "$1" ;;
+    esac
+}
+
+get_version() {
+    local tool="$1"
+    case "$tool" in
+        rust) rustc --version 2>/dev/null | awk '{print $2}' ;;
+        tmux) tmux -V 2>/dev/null | awk '{print $2}' ;;
+        glab) glab --version 2>/dev/null | awk '{print $3}' ;;
+        *)    "$tool" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+[0-9.]*' | head -1 ;;
+    esac
+}
+
+while IFS= read -r line; do
+    # Skip comments and blank lines
+    case "$line" in \#*|"") continue ;; esac
+
+    tool=$(echo "$line" | awk '{print $1}')
+    expected=$(echo "$line" | awk '{print $2}')
+    binary=$(get_binary "$tool")
+
+    if command -v "$binary" &>/dev/null; then
+        installed=$(get_version "$tool")
+        if [ "$installed" = "$expected" ]; then
+            pass "$tool $installed"
+        else
+            warn "$tool $installed (expected $expected)"
+        fi
+    else
+        fail "$tool not found (binary: $binary)"
+    fi
+done < "$REPO_ROOT/.tool-versions"

--- a/tests/check-asdf-tools.sh
+++ b/tests/check-asdf-tools.sh
@@ -35,6 +35,11 @@ get_version() {
     esac
 }
 
+if [ ! -f "$REPO_ROOT/.tool-versions" ]; then
+    warn ".tool-versions not found — skipping asdf version checks"
+    exit 0
+fi
+
 while IFS= read -r line; do
     # Skip comments and blank lines
     case "$line" in \#*|"") continue ;; esac

--- a/tests/check-asdf-tools.sh
+++ b/tests/check-asdf-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that asdf tools from .tool-versions are installed with expected versions.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/check-cargo-tools.sh
+++ b/tests/check-cargo-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that cargo-installed tools from manifest.toml are available.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -15,11 +15,13 @@ if ! command -v cargo &>/dev/null; then
     exit 0
 fi
 
-"$REPO_ROOT/helpers/read-manifest.py" cargo.tools | while IFS= read -r tool; do
-    if command -v "$tool" &>/dev/null; then
-        version=$("$tool" --version 2>/dev/null | head -1)
-        pass "$tool ($version)"
+"$REPO_ROOT/helpers/read-manifest.py" cargo.tools --format tsv --fields "crate,binary:" \
+    | while IFS=$'\t' read -r crate binary; do
+    binary="${binary:-$crate}"
+    if command -v "$binary" &>/dev/null; then
+        version=$("$binary" --version 2>/dev/null | head -1)
+        pass "$crate ($version)"
     else
-        fail "$tool not found"
+        fail "$crate not found (binary: $binary)"
     fi
 done

--- a/tests/check-cargo-tools.sh
+++ b/tests/check-cargo-tools.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Check that cargo-installed tools from manifest.toml are available.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/helpers.sh"
+
+section "Cargo Tools"
+
+if ! command -v cargo &>/dev/null; then
+    fail "cargo not found in PATH"
+    exit 0
+fi
+
+"$REPO_ROOT/helpers/read-manifest.py" cargo.tools | while IFS= read -r tool; do
+    if command -v "$tool" &>/dev/null; then
+        version=$("$tool" --version 2>/dev/null | head -1)
+        pass "$tool ($version)"
+    else
+        fail "$tool not found"
+    fi
+done

--- a/tests/check-non-asdf-tools.sh
+++ b/tests/check-non-asdf-tools.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Check that non-asdf resources from manifest.toml are present.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/helpers.sh"
+
+section "Non-asdf Tools"
+
+expand_path() {
+    local p="$1"
+    # Expand ~ to $HOME, resolve relative paths against repo root
+    p="${p/#\~/$HOME}"
+    if [[ "$p" != /* ]]; then
+        p="$REPO_ROOT/$p"
+    fi
+    echo "$p"
+}
+
+"$REPO_ROOT/helpers/read-manifest.py" resources --format jsonl | while IFS= read -r line; do
+    name=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
+    rtype=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['type'])")
+    rpath=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])")
+    rpath=$(expand_path "$rpath")
+
+    case "$rtype" in
+        git-clone)
+            if [ -d "$rpath/.git" ]; then
+                pass "$name ($rpath)"
+            else
+                fail "$name not found at $rpath"
+            fi
+            ;;
+        file-download)
+            if [ -f "$rpath" ]; then
+                pass "$name ($rpath)"
+            else
+                fail "$name not found at $rpath"
+            fi
+            ;;
+        *)
+            warn "$name: unknown resource type '$rtype'"
+            ;;
+    esac
+done

--- a/tests/check-non-asdf-tools.sh
+++ b/tests/check-non-asdf-tools.sh
@@ -20,10 +20,9 @@ expand_path() {
     echo "$p"
 }
 
-"$REPO_ROOT/helpers/read-manifest.py" resources --format jsonl | while IFS= read -r line; do
-    name=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
-    rtype=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['type'])")
-    rpath=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])")
+"$REPO_ROOT/helpers/read-manifest.py" resources --format tsv \
+    --fields "name,type,path" \
+    | while IFS=$'\t' read -r name rtype rpath; do
     rpath=$(expand_path "$rpath")
 
     case "$rtype" in

--- a/tests/check-non-asdf-tools.sh
+++ b/tests/check-non-asdf-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that non-asdf resources from manifest.toml are present.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/check-symlinks.sh
+++ b/tests/check-symlinks.sh
@@ -14,10 +14,9 @@ expand_path() {
     echo "${1/#\~/$HOME}"
 }
 
-"$REPO_ROOT/helpers/read-manifest.py" symlinks --format jsonl | while IFS= read -r line; do
-    src=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['source'])")
-    tgt=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['target'])")
-    typ=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type','symlink'))")
+"$REPO_ROOT/helpers/read-manifest.py" symlinks --format tsv \
+    --fields "source,target,type:symlink" \
+    | while IFS=$'\t' read -r src tgt typ; do
     tgt=$(expand_path "$tgt")
 
     case "$typ" in

--- a/tests/check-symlinks.sh
+++ b/tests/check-symlinks.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Check that symlinks from manifest.toml are correctly set up.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/helpers.sh"
+
+section "Symlinks"
+
+expand_path() {
+    echo "${1/#\~/$HOME}"
+}
+
+"$REPO_ROOT/helpers/read-manifest.py" symlinks --format jsonl | while IFS= read -r line; do
+    src=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['source'])")
+    tgt=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin)['target'])")
+    typ=$(printf '%s' "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type','symlink'))")
+    tgt=$(expand_path "$tgt")
+
+    case "$typ" in
+        symlink)
+            if [ -L "$tgt" ]; then
+                actual=$(resolve_path "$tgt")
+                expected=$(resolve_path "$REPO_ROOT/$src")
+                if [ "$actual" = "$expected" ]; then
+                    pass "$tgt → $src"
+                else
+                    fail "$tgt → $(basename "$actual") (expected $src)"
+                fi
+            elif [ -e "$tgt" ]; then
+                fail "$tgt exists but is not a symlink"
+            else
+                fail "$tgt missing"
+            fi
+            ;;
+        copy)
+            if [ -f "$tgt" ]; then
+                pass "$tgt exists (copy)"
+            else
+                fail "$tgt not found (expected copy of $src)"
+            fi
+            ;;
+        glob)
+            src_pattern="$REPO_ROOT/$src"
+            tgt_dir=$(dirname "$tgt")
+            matches=0
+            for f in $src_pattern; do
+                [ -e "$f" ] || continue
+                base=$(basename "$f")
+                if [ -e "$tgt_dir/$base" ] || [ -L "$tgt_dir/$base" ]; then
+                    matches=$((matches + 1))
+                fi
+            done
+            if [ "$matches" -gt 0 ]; then
+                pass "$tgt ($matches files linked)"
+            else
+                fail "$tgt: no matching files found"
+            fi
+            ;;
+        *)
+            warn "Unknown symlink type '$typ' for $tgt"
+            ;;
+    esac
+done

--- a/tests/check-symlinks.sh
+++ b/tests/check-symlinks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that symlinks from manifest.toml are correctly set up.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/check-system-packages.sh
+++ b/tests/check-system-packages.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Check that system packages from manifest.toml are installed.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/helpers.sh"
+
+section "System Packages"
+
+if [[ "$OSTYPE" == darwin* ]]; then
+    manifest_key="packages.darwin.list"
+    check_installed() { brew list "$1" &>/dev/null; }
+elif [[ "$OSTYPE" == linux* ]]; then
+    manifest_key="packages.linux.list"
+    check_installed() { dpkg -s "$1" &>/dev/null; }
+else
+    fail "Unsupported OS: $OSTYPE"
+    exit 1
+fi
+
+"$REPO_ROOT/helpers/read-manifest.py" "$manifest_key" | while IFS= read -r pkg; do
+    if check_installed "$pkg"; then
+        pass "$pkg installed"
+    else
+        fail "$pkg not found"
+    fi
+done

--- a/tests/check-system-packages.sh
+++ b/tests/check-system-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that system packages from manifest.toml are installed.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/docker/Dockerfile.no-sudo
+++ b/tests/docker/Dockerfile.no-sudo
@@ -19,7 +19,8 @@ RUN apt-get update \
 ARG TEST_USER=testuser
 ARG TEST_UID=1000
 
-RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER}
+RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER} 2>/dev/null || \
+    useradd -m -d /home/${TEST_USER} -s /bin/bash ${TEST_USER}
 
 USER ${TEST_USER}
 WORKDIR /home/${TEST_USER}

--- a/tests/docker/Dockerfile.no-sudo
+++ b/tests/docker/Dockerfile.no-sudo
@@ -1,0 +1,27 @@
+FROM ubuntu:24.04
+
+# Bootstrap: install python3 first so we can parse manifest.toml
+RUN apt-get update && apt-get install -y python3 curl git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy manifest + helper to parse package list
+COPY manifest.toml /tmp/manifest.toml
+COPY helpers/read-manifest.py /tmp/read-manifest.py
+
+# Install all system packages from manifest
+RUN apt-get update \
+    && apt-get install -y $(python3 /tmp/read-manifest.py \
+         --manifest /tmp/manifest.toml packages.linux.list \
+         | tr '\n' ' ') \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && rm /tmp/manifest.toml /tmp/read-manifest.py
+
+ARG TEST_USER=testuser
+ARG TEST_UID=1000
+
+RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER}
+
+USER ${TEST_USER}
+WORKDIR /home/${TEST_USER}
+RUN mkdir -p /home/${TEST_USER}/.local/bin
+ENV PATH="/home/${TEST_USER}/.local/bin:${PATH}"

--- a/tests/docker/Dockerfile.sudo
+++ b/tests/docker/Dockerfile.sudo
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get upgrade -y \
 ARG TEST_USER=testuser
 ARG TEST_UID=1000
 
-RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER} \
+RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER} 2>/dev/null || \
+    useradd -m -d /home/${TEST_USER} -s /bin/bash ${TEST_USER} \
     && printf '%s ALL=(ALL) NOPASSWD:ALL\n' "${TEST_USER}" > /etc/sudoers.d/99-testuser \
     && chmod 0440 /etc/sudoers.d/99-testuser
 

--- a/tests/docker/Dockerfile.sudo
+++ b/tests/docker/Dockerfile.sudo
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y sudo curl git python3 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ARG TEST_USER=testuser
+ARG TEST_UID=1000
+
+RUN useradd -m -d /home/${TEST_USER} -s /bin/bash -u ${TEST_UID} ${TEST_USER} \
+    && printf '%s ALL=(ALL) NOPASSWD:ALL\n' "${TEST_USER}" > /etc/sudoers.d/99-testuser \
+    && chmod 0440 /etc/sudoers.d/99-testuser
+
+USER ${TEST_USER}
+WORKDIR /home/${TEST_USER}
+RUN mkdir -p /home/${TEST_USER}/.local/bin
+ENV PATH="/home/${TEST_USER}/.local/bin:${PATH}"

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -19,6 +19,8 @@ if [ ! -s "$SANITY_COUNTERS_FILE" ]; then
 fi
 
 _update_counter() {
+    # NOTE: Non-atomic read-modify-write — check scripts must run sequentially.
+    # Parallelising them (e.g. with &) would corrupt counter state.
     local field="$1"  # 1=pass, 2=fail, 3=warn
     local counters
     counters=$(cat "$SANITY_COUNTERS_FILE")

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -62,9 +62,6 @@ summary() {
     [ "$f" -eq 0 ]
 }
 
-resolve_path() {
-    # Portable readlink -f: works on both Linux (GNU) and macOS ARM (BSD).
-    # Falls back to Python when GNU coreutils are unavailable.
-    readlink -f "$1" 2>/dev/null \
-        || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-}
+# shellcheck source=../helpers/shell-utils.sh
+_SCRIPT_DIR_HELPERS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$_SCRIPT_DIR_HELPERS/../helpers/shell-utils.sh"

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Shared TAP-like output functions for sanity check scripts.
+# Sourced by each check-*.sh and by test.sh.
+
+_GREEN='\033[0;32m'
+_RED='\033[0;31m'
+_YELLOW='\033[0;33m'
+_BOLD='\033[1m'
+_NC='\033[0m'
+
+# Counters file — shared across sub-scripts via environment variable.
+# Each sub-script sources this file and reads/writes the same counters file,
+# so the orchestrator (test.sh) sees aggregated totals.
+SANITY_COUNTERS_FILE="${SANITY_COUNTERS_FILE:-$(mktemp)}"
+export SANITY_COUNTERS_FILE
+
+if [ ! -s "$SANITY_COUNTERS_FILE" ]; then
+    printf '0 0 0' > "$SANITY_COUNTERS_FILE"
+fi
+
+_update_counter() {
+    local field="$1"  # 1=pass, 2=fail, 3=warn
+    local counters
+    counters=$(cat "$SANITY_COUNTERS_FILE")
+    local p f w
+    read -r p f w <<< "$counters"
+    case "$field" in
+        1) p=$((p + 1)) ;;
+        2) f=$((f + 1)) ;;
+        3) w=$((w + 1)) ;;
+    esac
+    printf '%d %d %d' "$p" "$f" "$w" > "$SANITY_COUNTERS_FILE"
+}
+
+pass() {
+    _update_counter 1
+    printf "  ${_GREEN}✓${_NC} %s\n" "$1"
+}
+
+fail() {
+    _update_counter 2
+    printf "  ${_RED}✗${_NC} %s\n" "$1"
+}
+
+warn() {
+    _update_counter 3
+    printf "  ${_YELLOW}⚠${_NC} %s\n" "$1"
+}
+
+section() {
+    printf "\n${_BOLD}=== %s ===${_NC}\n" "$1"
+}
+
+summary() {
+    local counters
+    counters=$(cat "$SANITY_COUNTERS_FILE")
+    local p f w
+    read -r p f w <<< "$counters"
+    printf "\n${_BOLD}════════════════════════${_NC}\n"
+    printf "  Results: ${_GREEN}%d passed${_NC}, ${_RED}%d failed${_NC}, ${_YELLOW}%d warnings${_NC}\n" "$p" "$f" "$w"
+    printf "${_BOLD}════════════════════════${_NC}\n"
+    [ "$f" -eq 0 ]
+}
+
+resolve_path() {
+    # Portable readlink -f: works on both Linux (GNU) and macOS ARM (BSD).
+    # Falls back to Python when GNU coreutils are unavailable.
+    readlink -f "$1" 2>/dev/null \
+        || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}

--- a/zsh_completions
+++ b/zsh_completions
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-if [ -d "${HOME}/.bash_completion.d" ]; then
-  for completion in "${HOME}"/.bash_completion.d/*.sh; do
-    if [ -x "$completion" ]; then
+if [ -d "${HOME}/.zsh_completion.d" ]; then
+  for completion in "${HOME}"/.zsh_completion.d/*; do
+    if [ -f "$completion" ] && [ -x "$completion" ]; then
       #echo "Reading completion file: $completion"
-      . $completion
+      . "$completion"
+    elif [ -f "$completion" ]; then
+      . "$completion"
     fi
   done
   unset completion

--- a/zsh_completions
+++ b/zsh_completions
@@ -2,10 +2,7 @@
 
 if [ -d "${HOME}/.zsh_completion.d" ]; then
   for completion in "${HOME}"/.zsh_completion.d/*; do
-    if [ -f "$completion" ] && [ -x "$completion" ]; then
-      #echo "Reading completion file: $completion"
-      . "$completion"
-    elif [ -f "$completion" ]; then
+    if [ -f "$completion" ]; then
       . "$completion"
     fi
   done

--- a/zshrc
+++ b/zshrc
@@ -123,9 +123,17 @@ if [[ -L "${XDG_CONFIG_HOME}/fzf/fzf.zsh" || -f "${XDG_CONFIG_HOME}/fzf/fzf.zsh"
   source "${XDG_CONFIG_HOME}/fzf/fzf.zsh"
 fi
 
-if [[ -L "${XDG_CONFIG_HOME}/cargo/env" || -f "${XDG_CONFIG_HOME}/cargo/env" ]]; then
-  echo "  󱣘 cargo"
-  source "${XDG_CONFIG_HOME}/cargo/env"
+# Setup cargo (required for all environments: docker, ubuntu, mac, vm, qemu, etc.)
+# Source cargo/env if it exists, otherwise set CARGO_HOME and add to PATH
+CARGO_HOME="${XDG_CONFIG_HOME}/cargo"
+CARGO_ENV="${CARGO_HOME}/env"
+if [ -f "${CARGO_ENV}" ]; then
+  source "${CARGO_ENV}"
+elif [ -d "${CARGO_HOME}/bin" ]; then
+  # Fallback: add cargo/bin to PATH directly if env file doesn't exist
+  if [[ ! "$PATH" == *"${CARGO_HOME}/bin"* ]]; then
+    export PATH="${CARGO_HOME}/bin:${PATH}"
+  fi
 fi
 
 if command -v zoxide &> /dev/null ; then


### PR DESCRIPTION
## Summary

- Implement manifest.toml as single source of truth for packages, tools, symlinks, and resources
- Create Python helper (read-manifest.py) for TOML parsing and shell consumption
- Build comprehensive sanity test framework with 5 check scripts (system packages, asdf tools, cargo tools, non-asdf resources, symlinks)
- Refactor install.sh to consume manifest instead of hardcoded arrays
- Add Docker test support with Dockerfile.sudo and Dockerfile.no-sudo

## Implementation Details

**Phase 1: Foundation**
- Task 1: manifest.toml (single source of truth)
- Task 2: helpers/read-manifest.py (Python 3.11+ TOML parser)

**Phase 2: Test Framework**
- Task 3: tests/helpers.sh (TAP-like output, counter sharing)
- Tasks 4-8: Five check scripts (packages, asdf, cargo, resources, symlinks)

**Phase 3: CLI + Validation**
- Task 9: test.sh CLI (build-image, sanity-check commands)
- Task 10: Local validation and bug fixes

**Phase 4: install.sh Refactoring**
- Task 11: Manifest-based system packages (get_system_package_list, install_sys_packages)
- Task 12: Manifest-based symlinks (resolve_path for macOS ARM, create_backups)
- Task 13: Manifest-based resources (install_non_asdf_tools)
- Task 14: asdf plugins refactoring (glab + cargo from manifest)
- Task 15: Full validation

**Phase 5: Docker Support**
- Task 16: Docker test images (Dockerfile.sudo, Dockerfile.no-sudo)
- Task 17: Docker workflow testing

## Test Plan

- [x] Verify manifest.toml syntax with tomllib
- [x] Verify read-manifest.py reads all manifest sections correctly
- [x] Verify helpers.sh functions work (pass/fail/warn/summary)
- [x] Verify each check script runs successfully
- [x] Verify test.sh CLI orchestrates all checks
- [x] Verify install.sh refactoring maintains functionality
- [x] Verify Docker Dockerfiles are valid
- [x] All 9 commits reviewed and pass local testing

**Notes:**
- resolve_path() provides macOS ARM compatibility (no GNU readlink -f)
- manifest.toml includes optional fields: branch, shallow, post_install, backup=false
- Test framework uses TAP-like colored output with shared counter file
- Sanity checks handle version mismatches (warn) vs missing tools (fail)