### PR TITLE
feat(aliases): Replace exa with eza and enhance with latest features

### DIFF
--- a/zsh_aliases.d/001-basic.sh
+++ b/zsh_aliases.d/001-basic.sh
@@ -140,12 +140,15 @@ function fqi() {
 ##
 ################################################################################
 
-# Use exa instead of ls
-alias ls="exa"
-alias ll="exa -l"
-alias lla="exa -la"
-alias tree="exa -T"
-alias treel="exa -Tl"
+# Use eza instead of ls (modern replacement for exa)
+alias ls="eza --icons --group-directories-first"
+alias ll="eza -l --icons --group-directories-first"
+alias lla="eza -la --icons --group-directories-first"
+alias llt="eza -lT --icons --group-directories-first"
+alias llta="eza -lTa --icons --group-directories-first"
+alias tree="eza -T --icons --group-directories-first"
+alias treel="eza -lT --icons --group-directories-first"
+alias treela="eza -lTa --icons --group-directories-first"
 
 # FZF
 alias fprv="fzf --preview 'bat --color=always --style=numbers {}'"

--- a/zshrc
+++ b/zshrc
@@ -83,13 +83,6 @@ zstyle ':fzf-tab:*' fzf-command ftb-tmux-popup
 bindkey "^[[1;5C" forward-word
 bindkey "^[[1;5D" backward-word
 
-# Aliases
-alias ls="exa"
-alias ll="exa -l"
-alias lla="exa -la"
-alias tree="exa -T"
-alias treel="exa -Tl"
-
 if [[ ! "$PATH" == *${HOME}/.local/bin* ]]; then
   export PATH="$HOME/.local/bin:${PATH:+${PATH}:}"
 fi


### PR DESCRIPTION
## Overview
Replace the legacy exa command-line tool with eza, which is a modern, actively maintained fork that provides better features and performance.

## Changes
- **Replaced exa with eza**: Updated all alias definitions to use the modern eza fork
- **Enhanced with icons**: Added `--icons` flag for better visual file type identification
- **Improved organization**: Added `--group-directories-first` to keep directories at the top of listings
- **New aliases**: Added convenient shortcuts:
  - `llt`: Tree view with long format
  - `llta`: Tree view with long format and hidden files
  - `treela`: Tree view including hidden files
- **Cleaned up duplicates**: Removed redundant alias definitions from zshrc (now sourced from aliases.d)

## Benefits
- ✅ More modern, actively maintained tool
- ✅ Better visual presentation with icons
- ✅ Improved directory organization in listings
- ✅ Additional convenience aliases for common tasks
- ✅ Cleaner config with DRY principle (aliases defined in one place)