### PR TITLE
feat(starship): reorganize config to config/starship/config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *~
 *.bkp*
 
-config/starship.toml
+config/starship/config.toml
 
 .gitrepos
 .fzf

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no
 COPY docker/scripts/sshd_dev_config /etc/ssh/
 COPY docker/scripts/init_dev_docker.sh /usr/bin/
 COPY bashrc ${DEV_HOME}/.bashrc
-COPY config/starship.toml ${DEV_HOME}/.config/starship.toml
+COPY config/starship/config.toml ${DEV_HOME}/.config/starship/config.toml
  
 CMD ["/usr/bin/init_dev_docker.sh"]

--- a/bashrc
+++ b/bashrc
@@ -108,7 +108,7 @@ echo "setting up..."
 
 if command -v starship &> /dev/null ; then
   echo "   starship"
-  export STARSHIP_CONFIG="${XDG_CONFIG_HOME}/starship.toml"
+  export STARSHIP_CONFIG="${XDG_CONFIG_HOME}/starship/config.toml"
   eval "$(starship init bash)"
 fi
 

--- a/config/starship/config.toml
+++ b/config/starship/config.toml
@@ -1,1 +1,1 @@
-./presets/starship-powerline-solar.toml
+./presets/starship-powerline-gradient-solar.toml

--- a/config/starship/config.toml
+++ b/config/starship/config.toml
@@ -1,0 +1,1 @@
+./presets/starship-powerline-solar.toml

--- a/install.sh
+++ b/install.sh
@@ -270,13 +270,16 @@ function apply_dotfiles() {
     esac
   done
 
-  # Initialize default Starship preset
-  backup_this "${XDG_CONFIG_HOME}/starship.toml"
-  default_preset="config/starship/presets/starship-clean-gradient-aurora.toml"
-  if [ -f "$default_preset" ]; then
-    ln -sf "$(readlink -f "$default_preset")" "config/starship.toml"
+  # Initialize default Starship preset (only if not already configured)
+  if [ ! -e "config/starship/config.toml" ]; then
+    default_preset="config/starship/presets/starship-powerline-solar.toml"
+    if [ -f "$default_preset" ]; then
+      ln -sf "$(readlink -f "$default_preset")" "config/starship/config.toml"
+    fi
   fi
-  ln -sf "$(readlink -f config/starship.toml)" "${XDG_CONFIG_HOME}/"
+  backup_this "${XDG_CONFIG_HOME}/starship/config.toml"
+  mkdir -p "${XDG_CONFIG_HOME}/starship"
+  ln -sf "$(readlink -f config/starship/config.toml)" "${XDG_CONFIG_HOME}/starship/"
 
   # gitconfig special handling: set user name/email after copy
   if [ -n "$GIT_USER_NAME" ]; then

--- a/manifest.toml
+++ b/manifest.toml
@@ -151,8 +151,8 @@ target = "~/.zsh_completion.d"
 backup = false
 
 [[symlinks]]
-source = "config/starship.toml"
-target = "~/.config/starship.toml"
+source = "config/starship/config.toml"
+target = "~/.config/starship/config.toml"
 
 [[symlinks]]
 source = "config/fzf.zsh"

--- a/zshrc
+++ b/zshrc
@@ -135,7 +135,7 @@ echo "setting up..."
 
 if command -v starship &> /dev/null ; then
   echo "   starship"
-  export STARSHIP_CONFIG="${XDG_CONFIG_HOME}/starship.toml"
+  export STARSHIP_CONFIG="${XDG_CONFIG_HOME}/starship/config.toml"
   eval "$(starship init zsh)"
 fi
 


### PR DESCRIPTION
## Summary
Moves starship configuration from `config/starship.toml` to `config/starship/config.toml`, keeping presets and active config colocated. Updates all references across the repo.

## Why
Better organization: presets and the active config now live in the same directory, making the structure more discoverable and maintainable.