### PR TITLE
fix(starship): fix picker paths, XDG chain, and preset symlink

### DIFF
--- a/bin/starship-picker
+++ b/bin/starship-picker
@@ -45,10 +45,10 @@ for arg in "$@"; do
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || dirname "$SCRIPT_DIR")"
 CONFIG_DIR="$REPO_ROOT/config"
-STARSHIP_TOML="$CONFIG_DIR/starship.toml"
+STARSHIP_TOML="$CONFIG_DIR/starship/config.toml"
 PRESETS_DIR="$CONFIG_DIR/starship/presets"
 
 # If starship.toml doesn't exist, create a symlink to the first preset
@@ -117,6 +117,16 @@ if [[ -L "$STARSHIP_TOML" ]]; then
   echo "$(readlink "$STARSHIP_TOML")" > "$BACKUP"
 else
   cp "$STARSHIP_TOML" "$BACKUP"
+fi
+
+# Self-heal: ~/.config/starship/config.toml must chain through the repo's
+# config.toml, not point directly to a preset. A previous install using
+# readlink -f would have bypassed the chain, making picker updates invisible
+# to starship and breaking live preview.
+_XDG_STARSHIP="${XDG_CONFIG_HOME:-$HOME/.config}/starship/config.toml"
+if [[ "$(readlink "$_XDG_STARSHIP" 2>/dev/null)" != "$STARSHIP_TOML" ]]; then
+  mkdir -p "$(dirname "$_XDG_STARSHIP")"
+  ln -sf "$STARSHIP_TOML" "$_XDG_STARSHIP"
 fi
 
 # Create test directories upfront for fast previews (no runtime flicker)

--- a/install.sh
+++ b/install.sh
@@ -271,21 +271,23 @@ function apply_dotfiles() {
   done
 
   # Remove old dangling symlink if it exists
-  if [ -L "config/starship.toml" ]; then
+  if [ -L "$script_dir/config/starship.toml" ]; then
     echo "Removing old symlink config/starship.toml"
-    rm "config/starship.toml"
+    rm "$script_dir/config/starship.toml"
   fi
 
-  # Initialize default Starship preset (only if not already configured)
-  if [ ! -e "config/starship/config.toml" ]; then
-    default_preset="config/starship/presets/starship-powerline-solar.toml"
+  # Initialize the repo-side symlink (only if not already configured).
+  # The manifest-driven loop above creates:
+  #   ~/.config/starship/config.toml → <repo>/config/starship/config.toml
+  # This step ensures the repo-side symlink exists so starship can read it
+  # immediately after install. starship-picker later re-points it to any
+  # chosen preset: <repo>/config/starship/config.toml → presets/<chosen>.toml
+  if [ ! -e "$script_dir/config/starship/config.toml" ]; then
+    default_preset="$script_dir/config/starship/presets/starship-powerline-solar.toml"
     if [ -f "$default_preset" ]; then
-      ln -sf "$(readlink -f "$default_preset")" "config/starship/config.toml"
+      ln -s "$default_preset" "$script_dir/config/starship/config.toml"
     fi
   fi
-  backup_this "${XDG_CONFIG_HOME}/starship/config.toml"
-  mkdir -p "${XDG_CONFIG_HOME}/starship"
-  ln -sf "$(readlink -f config/starship/config.toml)" "${XDG_CONFIG_HOME}/starship/"
 
   # gitconfig special handling: set user name/email after copy
   if [ -n "$GIT_USER_NAME" ]; then

--- a/manifest.toml
+++ b/manifest.toml
@@ -155,6 +155,10 @@ source = "config/starship/config.toml"
 target = "~/.config/starship/config.toml"
 
 [[symlinks]]
+source = "config/starship/presets"
+target = "~/.config/starship/presets"
+
+[[symlinks]]
 source = "config/fzf.zsh"
 target = "~/.config/fzf/fzf.zsh"
 


### PR DESCRIPTION
## Summary
- Fixed starship picker installation paths
- Corrected XDG Base Directory Specification chain
- Fixed preset symlink handling

## Why
These fixes ensure the starship-picker tool is installed with correct paths and respects XDG conventions properly.