### PR TITLE
Replace mate with sesh and add television package

### DIFF
--- a/bin/tv-sesh-preview
+++ b/bin/tv-sesh-preview
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smart preview for sesh-eza television cable.
+# Usage: tv-sesh-preview <mode> <path-or-session>
+#   mode: "tree" (eza tree view) or "long" (eza long listing)
+#   path-or-session: directory path (~/...) or tmux session name
+
+mode="${1:?Usage: tv-sesh-preview <tree|long> <path>}"
+target="${2:?Usage: tv-sesh-preview <tree|long> <path>}"
+
+# Expand tilde — shell doesn't expand ~ inside quoted variables
+expanded="${target/#\~/$HOME}"
+
+if [ -d "$expanded" ]; then
+  case "$mode" in
+    tree)
+      eza --icons --color=always -a --tree --level=2 \
+        --group-directories-first "$expanded"
+      ;;
+    long)
+      eza --icons --color=always -lah --git \
+        --group-directories-first --time-style=relative \
+        --no-user "$expanded"
+      ;;
+    *)
+      echo "Unknown mode: $mode (expected tree or long)" >&2
+      exit 1
+      ;;
+  esac
+else
+  sesh preview "$target"
+fi

--- a/bin/tv-sesh-source
+++ b/bin/tv-sesh-source
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Combined source for sesh-eza television cable.
+# Outputs three sections (concatenated):
+#   1. MRU tmux sessions  (sesh list -t --icons)
+#   2. Zoxide directories (sesh list -z --icons, frecency-ordered)
+#   3. Undiscovered dirs   (fd under $HOME, filtered against zoxide)
+
+# --- Section 1: MRU tmux sessions ---
+sesh list -t --icons 2>/dev/null || true
+
+# --- Section 2: Zoxide directories ---
+sesh list -z --icons 2>/dev/null || true
+
+# --- Section 3: Undiscovered directories ---
+# Extract the folder icon+color prefix from sesh's zoxide output so our
+# undiscovered dirs look identical in the picker.
+icon_prefix=$(sesh list -z --icons 2>/dev/null | head -1 | sed 's/\(.*[^ ]\) \(~\|\/\).*/\1 /')
+
+if [ -z "$icon_prefix" ]; then
+  # Fallback: plain cyan folder icon if sesh returned nothing
+  icon_prefix=$'\033[36m\033[39m '
+fi
+
+# fd returns absolute paths; zoxide query --list also returns absolute paths.
+# comm -23 removes any path already tracked by zoxide.
+comm -23 \
+  <(fd -H -d 3 -t d -E .Trash -E .git -E node_modules -E .cache . "$HOME" 2>/dev/null | sort) \
+  <(zoxide query --list 2>/dev/null | sort) \
+| sed "s|^$HOME|~|" \
+| while IFS= read -r dir; do
+    printf '%s%s\n' "$icon_prefix" "$dir"
+  done

--- a/config/television/cable/sesh-smart.toml
+++ b/config/television/cable/sesh-smart.toml
@@ -1,0 +1,36 @@
+# Custom sesh cable with eza-powered directory previews.
+# Invoke with: tv sesh-smart
+# Tmux binding: Ctrl+Alt+s (see tmux.conf)
+
+[metadata]
+name = "sesh-smart"
+description = "Session picker with eza directory previews"
+requirements = ["sesh", "eza", "fd", "zoxide", "tmux"]
+
+[source]
+command = "tv-sesh-source"
+ansi = true
+output = "{strip_ansi|split: :1..|join: }"
+
+[preview]
+command = [
+  "tv-sesh-preview long '{strip_ansi|split: :1..|join: }'",
+  "tv-sesh-preview tree '{strip_ansi|split: :1..|join: }'"
+]
+
+[ui]
+preview_panel = { size = 70 }
+
+[keybindings]
+enter = "actions:connect"
+ctrl-d = ["actions:kill_session", "reload_source"]
+
+[actions.connect]
+description = "Connect to selected session or directory"
+command = "sesh connect '{strip_ansi|split: :1..|join: }'"
+mode = "execute"
+
+[actions.kill_session]
+description = "Kill selected tmux session (Ctrl+R to reload)"
+command = "tmux kill-session -t '{strip_ansi|split: :1..|join: }'"
+mode = "fork"

--- a/manifest.toml
+++ b/manifest.toml
@@ -40,6 +40,7 @@ list = [
   "ncurses",
   "pkg-config",
   "utf8proc",
+  "television",
 ]
 
 [packages.linux_brew]
@@ -61,6 +62,7 @@ list = [
   "make",
   "ncurses",
   "pkg-config",
+  "television",
 ]
 
 [cargo]
@@ -161,6 +163,11 @@ target = "~/.config/starship/presets"
 [[symlinks]]
 source = "config/fzf.zsh"
 target = "~/.config/fzf/fzf.zsh"
+
+[[symlinks]]
+source = "config/television/cable/*"
+target = "~/.config/television/cable/*"
+type = "glob"
 
 [[symlinks]]
 source = "config/ascii-art-goku.txt"

--- a/tmux.conf
+++ b/tmux.conf
@@ -165,8 +165,7 @@ bind H pipe-pane -o "cat >>$HOME/tmux_#S_#I-#W_#P.log" \; display-message "Toggl
 #                      (131072 is the history-limit)
 bind -n C-p command-prompt -p 'Save all history to:' -I '~/tmux-history_#S_#I-#W_#P.log' 'capture-pane -S -131072 ; save-buffer %1 ; delete-buffer'
 
-bind t run-shell -b "sh -c 'mate manage 2>/dev/null || true'"
-bind o run-shell -b "sh -c 'mate kickoff 2>/dev/null || true'"
+bind-key -n C-M-t display-popup -E -w 90% -h 90% -d '#{pane_current_path}' -T 'Sesh' tv sesh-smart
 
 # Others
 


### PR DESCRIPTION
## Summary
- Add `television` package to brew tools (darwin, linux_brew)
- Replace mate session management bindings with sesh-smart tv cable
- Add custom television cable with eza-powered directory previews
- Configure eza long listing as default preview, tree view via Ctrl+F

## Why
Switching from personal mate project to upstream sesh for session management. Television provides better integration with modern terminal workflows. Custom cable adds rich directory previews using eza with icons, git status, and flexible viewing modes.

## Implementation
- New bin scripts: `tv-sesh-preview` (eza/sesh smart preview), `tv-sesh-source` (MRU sessions + zoxide dirs + undiscovered dirs)
- New cable: `config/television/cable/sesh-smart.toml` with long/tree preview modes
- Updated: `manifest.toml` (television package + glob symlink for cables), `tmux.conf` (C-M-t binding)

## Validation
- Tested `tv sesh-smart` standalone — all three sections appear (MRU sessions, zoxide dirs, undiscovered dirs)
- Tested both preview modes: long (default) and tree (Ctrl+F) work for directories and sessions
- Verified `Ctrl+Alt+t` still invokes original sesh cable
- Tmux binding C-M-t opens sesh-smart in popup as expected