### PR TITLE
feat(tmux-palette): palette-driven pane tinting and status bar gradient

### DIFF
--- a/bin/tmux-palette
+++ b/bin/tmux-palette
@@ -68,6 +68,16 @@ _darken_hex() {
   printf '#%02x%02x%02x' $(( r * pct / 100 )) $(( g * pct / 100 )) $(( b * pct / 100 ))
 }
 
+_chroma_hex() {
+  local hex="${1#\#}"
+  [[ "$hex" =~ ^[0-9a-fA-F]{6}$ ]] || { echo 0; return; }
+  local r=$((16#${hex:0:2})) g=$((16#${hex:2:2})) b=$((16#${hex:4:2}))
+  local max min
+  max=$r; (( g > max )) && max=$g; (( b > max )) && max=$b
+  min=$r; (( g < min )) && min=$g; (( b < min )) && min=$b
+  echo $(( max - min ))
+}
+
 _is_light() {
   local hex="${1#\#}"
   [[ "$hex" =~ ^[0-9a-fA-F]{6}$ ]] || return 1
@@ -78,6 +88,8 @@ _is_light() {
 
 _contrast_fg() {
   local bg="$1" light_fg="${2:-#f8f8f2}" dark_fg="${3:-#1a1a2e}"
+  # If the proposed light_fg is itself dark, fall back to white
+  ! _is_light "$light_fg" && light_fg="#f8f8f2"
   if _is_light "$bg"; then
     printf '%s' "$dark_fg"
   else
@@ -95,22 +107,39 @@ _window_format() {
 # --- Apply modes ---
 
 _apply_preview() {
-  local bg="$c5"
+  local bg
+  bg=$(_darken_hex "$pfg" 18)
   $is_bracket && bg="default"
+
+  # Gradient base: whichever of c1/pfg has higher chroma (more saturated)
+  local gbase
+  if (( $(_chroma_hex "$c1") >= $(_chroma_hex "$pfg") )); then
+    gbase="$c1"
+  else
+    gbase="$pfg"
+  fi
+
+  # Generate 5-step gradient for segment backgrounds
+  local s1 s2 s3 s4 s5
+  s1=$(_darken_hex "$gbase" 100)
+  s2=$(_darken_hex "$gbase" 75)
+  s3=$(_darken_hex "$gbase" 55)
+  s4=$(_darken_hex "$gbase" 38)
+  s5=$(_darken_hex "$gbase" 25)
 
   # Compute contrast-safe foreground for each segment bg
   local cfg1 cfg2 cfg3 cfg4 cfg5
-  cfg1=$(_contrast_fg "$c1" "$pfg")
-  cfg2=$(_contrast_fg "$c2" "$pfg")
-  cfg3=$(_contrast_fg "$c3" "$pfg")
-  cfg4=$(_contrast_fg "$c4" "$pfg")
-  cfg5=$(_contrast_fg "$c5" "$pfg")
+  cfg1=$(_contrast_fg "$s1" "$pfg")
+  cfg2=$(_contrast_fg "$s2" "$pfg")
+  cfg3=$(_contrast_fg "$s3" "$pfg")
+  cfg4=$(_contrast_fg "$s4" "$pfg")
+  cfg5=$(_contrast_fg "$s5" "$pfg")
 
-  # Update Dracula color vars so segment backgrounds match the preset
-  local dracula_colors="p1='$c1'; p2='$c2'; p3='$c3'; p4='$c4'; p5='$c5'; pfg='$pfg'; "
+  # Update Dracula color vars with gradient segments
+  local dracula_colors="p1='$s1'; p2='$s2'; p3='$s3'; p4='$s4'; p5='$s5'; pfg='$pfg'; "
   dracula_colors+="cfg1='$cfg1'; cfg2='$cfg2'; cfg3='$cfg3'; cfg4='$cfg4'; cfg5='$cfg5'; "
-  dracula_colors+="green='$c1'; dark_gray='$bg'; gray='$c4'; "
-  dracula_colors+="light_purple='$c2'; dark_purple='$c3'; white='#f8f8f2'"
+  dracula_colors+="green='$s1'; dark_gray='$bg'; gray='$s4'; "
+  dracula_colors+="light_purple='$s2'; dark_purple='$s3'; white='#f8f8f2'"
   tmux set-option -g @dracula-colors "$dracula_colors"
 
   local status_right
@@ -123,12 +152,12 @@ _apply_preview() {
   local status_fg
   status_fg=$(_contrast_fg "$bg" "$pfg")
   tmux set-option -g status-style "bg=$bg,fg=$status_fg"
-  tmux set-option -g pane-active-border-style "fg=$c1,bg=$c1"
+  tmux set-option -g pane-active-border-style "fg=$s1,bg=$s1"
   tmux set-option -g pane-border-style "fg=$pfg"
-  tmux set-option -g message-style "bg=$c3,fg=$cfg3"
-  tmux set-option -g window-status-current-format "$(_window_format "$c1" "$c2")"
-  tmux set-option -g @palette-c1 "$c1"
-  tmux set-option -g @palette-c2 "$c2"
+  tmux set-option -g message-style "bg=$s3,fg=$cfg3"
+  tmux set-option -g window-status-current-format "$(_window_format "$s1" "$s2")"
+  tmux set-option -g @palette-c1 "$s1"
+  tmux set-option -g @palette-c2 "$s2"
   tmux set-option -g @palette-pfg "$pfg"
   tmux set-option -g @palette-title-fg "$cfg1"
   local inactive_bg
@@ -140,22 +169,39 @@ _apply_preview() {
 }
 
 _apply_full() {
-  local bg="$c5"
+  local bg
+  bg=$(_darken_hex "$pfg" 18)
   $is_bracket && bg="default"
+
+  # Gradient base: whichever of c1/pfg has higher chroma (more saturated)
+  local gbase
+  if (( $(_chroma_hex "$c1") >= $(_chroma_hex "$pfg") )); then
+    gbase="$c1"
+  else
+    gbase="$pfg"
+  fi
+
+  # Generate 5-step gradient for segment backgrounds
+  local s1 s2 s3 s4 s5
+  s1=$(_darken_hex "$gbase" 100)
+  s2=$(_darken_hex "$gbase" 75)
+  s3=$(_darken_hex "$gbase" 55)
+  s4=$(_darken_hex "$gbase" 38)
+  s5=$(_darken_hex "$gbase" 25)
 
   # Compute contrast-safe foreground for each segment bg
   local cfg1 cfg2 cfg3 cfg4 cfg5
-  cfg1=$(_contrast_fg "$c1" "$pfg")
-  cfg2=$(_contrast_fg "$c2" "$pfg")
-  cfg3=$(_contrast_fg "$c3" "$pfg")
-  cfg4=$(_contrast_fg "$c4" "$pfg")
-  cfg5=$(_contrast_fg "$c5" "$pfg")
+  cfg1=$(_contrast_fg "$s1" "$pfg")
+  cfg2=$(_contrast_fg "$s2" "$pfg")
+  cfg3=$(_contrast_fg "$s3" "$pfg")
+  cfg4=$(_contrast_fg "$s4" "$pfg")
+  cfg5=$(_contrast_fg "$s5" "$pfg")
 
   # @dracula-colors: define palette vars + override Dracula defaults
-  local dracula_colors="p1='$c1'; p2='$c2'; p3='$c3'; p4='$c4'; p5='$c5'; pfg='$pfg'; "
+  local dracula_colors="p1='$s1'; p2='$s2'; p3='$s3'; p4='$s4'; p5='$s5'; pfg='$pfg'; "
   dracula_colors+="cfg1='$cfg1'; cfg2='$cfg2'; cfg3='$cfg3'; cfg4='$cfg4'; cfg5='$cfg5'; "
-  dracula_colors+="green='$c1'; dark_gray='$bg'; gray='$c4'; "
-  dracula_colors+="light_purple='$c2'; dark_purple='$c3'; white='#f8f8f2'"
+  dracula_colors+="green='$s1'; dark_gray='$bg'; gray='$s4'; "
+  dracula_colors+="light_purple='$s2'; dark_purple='$s3'; white='#f8f8f2'"
   tmux set-option -g @dracula-colors "$dracula_colors"
 
   # Per-plugin color assignments (bg fg) — use contrast-safe fg
@@ -172,18 +218,18 @@ _apply_full() {
   if [[ -n "$status_right" ]]; then
     local dracula_script="$HOME/.config/tmux/plugins/tmux/dracula.tmux"
     [[ -x "$dracula_script" ]] && "$dracula_script"
-    tmux set-option -g window-status-current-format "$(_window_format "$c1" "$c2")"
+    tmux set-option -g window-status-current-format "$(_window_format "$s1" "$s2")"
   fi
 
   # Direct style options (startup + mid-session)
   local status_fg
   status_fg=$(_contrast_fg "$bg" "$pfg")
   tmux set-option -g status-style "bg=$bg,fg=$status_fg"
-  tmux set-option -g pane-active-border-style "fg=$c1,bg=$c1"
+  tmux set-option -g pane-active-border-style "fg=$s1,bg=$s1"
   tmux set-option -g pane-border-style "fg=$pfg"
-  tmux set-option -g message-style "bg=$c3,fg=$cfg3"
-  tmux set-option -g @palette-c1 "$c1"
-  tmux set-option -g @palette-c2 "$c2"
+  tmux set-option -g message-style "bg=$s3,fg=$cfg3"
+  tmux set-option -g @palette-c1 "$s1"
+  tmux set-option -g @palette-c2 "$s2"
   tmux set-option -g @palette-pfg "$pfg"
   tmux set-option -g @palette-title-fg "$cfg1"
   local inactive_bg

--- a/bin/tmux-palette
+++ b/bin/tmux-palette
@@ -60,6 +60,31 @@ _extract_palette() {
   fi
 }
 
+# --- Color math ---
+
+_darken_hex() {
+  local hex="${1#\#}" pct="${2:-12}"
+  local r=$((16#${hex:0:2})) g=$((16#${hex:2:2})) b=$((16#${hex:4:2}))
+  printf '#%02x%02x%02x' $(( r * pct / 100 )) $(( g * pct / 100 )) $(( b * pct / 100 ))
+}
+
+_is_light() {
+  local hex="${1#\#}"
+  [[ "$hex" =~ ^[0-9a-fA-F]{6}$ ]] || return 1
+  local r=$((16#${hex:0:2})) g=$((16#${hex:2:2})) b=$((16#${hex:4:2}))
+  local lum=$(( (299 * r + 587 * g + 114 * b) / 1000 ))
+  (( lum > 100 ))
+}
+
+_contrast_fg() {
+  local bg="$1" light_fg="${2:-#f8f8f2}" dark_fg="${3:-#1a1a2e}"
+  if _is_light "$bg"; then
+    printf '%s' "$dark_fg"
+  else
+    printf '%s' "$light_fg"
+  fi
+}
+
 # --- Window status format ---
 
 _window_format() {
@@ -73,8 +98,17 @@ _apply_preview() {
   local bg="$c5"
   $is_bracket && bg="default"
 
+  # Compute contrast-safe foreground for each segment bg
+  local cfg1 cfg2 cfg3 cfg4 cfg5
+  cfg1=$(_contrast_fg "$c1" "$pfg")
+  cfg2=$(_contrast_fg "$c2" "$pfg")
+  cfg3=$(_contrast_fg "$c3" "$pfg")
+  cfg4=$(_contrast_fg "$c4" "$pfg")
+  cfg5=$(_contrast_fg "$c5" "$pfg")
+
   # Update Dracula color vars so segment backgrounds match the preset
   local dracula_colors="p1='$c1'; p2='$c2'; p3='$c3'; p4='$c4'; p5='$c5'; pfg='$pfg'; "
+  dracula_colors+="cfg1='$cfg1'; cfg2='$cfg2'; cfg3='$cfg3'; cfg4='$cfg4'; cfg5='$cfg5'; "
   dracula_colors+="green='$c1'; dark_gray='$bg'; gray='$c4'; "
   dracula_colors+="light_purple='$c2'; dark_purple='$c3'; white='#f8f8f2'"
   tmux set-option -g @dracula-colors "$dracula_colors"
@@ -86,33 +120,51 @@ _apply_preview() {
     [[ -x "$dracula_script" ]] && "$dracula_script"
   fi
 
-  tmux set-option -g status-style "bg=$bg,fg=$pfg"
+  local status_fg
+  status_fg=$(_contrast_fg "$bg" "$pfg")
+  tmux set-option -g status-style "bg=$bg,fg=$status_fg"
   tmux set-option -g pane-active-border-style "fg=$c1,bg=$c1"
   tmux set-option -g pane-border-style "fg=$pfg"
-  tmux set-option -g message-style "bg=$c3,fg=$pfg"
+  tmux set-option -g message-style "bg=$c3,fg=$cfg3"
   tmux set-option -g window-status-current-format "$(_window_format "$c1" "$c2")"
   tmux set-option -g @palette-c1 "$c1"
   tmux set-option -g @palette-c2 "$c2"
   tmux set-option -g @palette-pfg "$pfg"
+  tmux set-option -g @palette-title-fg "$cfg1"
+  local inactive_bg
+  inactive_bg=$(_darken_hex "$pfg" 25)
+  tmux set-option -g @palette-active-bg "#1e1e2e"
+  tmux set-option -g window-active-style "bg=#1e1e2e,fg=terminal"
+  tmux set-option -g window-style "bg=$inactive_bg,fg=#c0c0c0"
+  tmux set-option -g @palette-inactive-bg "$inactive_bg"
 }
 
 _apply_full() {
   local bg="$c5"
   $is_bracket && bg="default"
 
+  # Compute contrast-safe foreground for each segment bg
+  local cfg1 cfg2 cfg3 cfg4 cfg5
+  cfg1=$(_contrast_fg "$c1" "$pfg")
+  cfg2=$(_contrast_fg "$c2" "$pfg")
+  cfg3=$(_contrast_fg "$c3" "$pfg")
+  cfg4=$(_contrast_fg "$c4" "$pfg")
+  cfg5=$(_contrast_fg "$c5" "$pfg")
+
   # @dracula-colors: define palette vars + override Dracula defaults
   local dracula_colors="p1='$c1'; p2='$c2'; p3='$c3'; p4='$c4'; p5='$c5'; pfg='$pfg'; "
+  dracula_colors+="cfg1='$cfg1'; cfg2='$cfg2'; cfg3='$cfg3'; cfg4='$cfg4'; cfg5='$cfg5'; "
   dracula_colors+="green='$c1'; dark_gray='$bg'; gray='$c4'; "
   dracula_colors+="light_purple='$c2'; dark_purple='$c3'; white='#f8f8f2'"
   tmux set-option -g @dracula-colors "$dracula_colors"
 
-  # Per-plugin color assignments (reference palette var names)
-  tmux set-option -g @dracula-ssh-session-colors "p1 p5"
-  tmux set-option -g @dracula-cwd-colors "p2 pfg"
-  tmux set-option -g @dracula-cpu-arch-colors "p3 pfg"
-  tmux set-option -g @dracula-cpu-usage-colors "p3 pfg"
-  tmux set-option -g @dracula-ram-usage-colors "p4 pfg"
-  tmux set-option -g @dracula-weather-colors "p4 pfg"
+  # Per-plugin color assignments (bg fg) — use contrast-safe fg
+  tmux set-option -g @dracula-ssh-session-colors "p1 cfg1"
+  tmux set-option -g @dracula-cwd-colors "p2 cfg2"
+  tmux set-option -g @dracula-cpu-arch-colors "p3 cfg3"
+  tmux set-option -g @dracula-cpu-usage-colors "p3 cfg3"
+  tmux set-option -g @dracula-ram-usage-colors "p4 cfg4"
+  tmux set-option -g @dracula-weather-colors "p4 cfg4"
 
   # Mid-session only: re-run Dracula + re-apply window format
   local status_right
@@ -124,13 +176,22 @@ _apply_full() {
   fi
 
   # Direct style options (startup + mid-session)
-  tmux set-option -g status-style "bg=$bg,fg=$pfg"
+  local status_fg
+  status_fg=$(_contrast_fg "$bg" "$pfg")
+  tmux set-option -g status-style "bg=$bg,fg=$status_fg"
   tmux set-option -g pane-active-border-style "fg=$c1,bg=$c1"
   tmux set-option -g pane-border-style "fg=$pfg"
-  tmux set-option -g message-style "bg=$c3,fg=$pfg"
+  tmux set-option -g message-style "bg=$c3,fg=$cfg3"
   tmux set-option -g @palette-c1 "$c1"
   tmux set-option -g @palette-c2 "$c2"
   tmux set-option -g @palette-pfg "$pfg"
+  tmux set-option -g @palette-title-fg "$cfg1"
+  local inactive_bg
+  inactive_bg=$(_darken_hex "$pfg" 25)
+  tmux set-option -g @palette-active-bg "#1e1e2e"
+  tmux set-option -g window-active-style "bg=#1e1e2e,fg=terminal"
+  tmux set-option -g window-style "bg=$inactive_bg,fg=#c0c0c0"
+  tmux set-option -g @palette-inactive-bg "$inactive_bg"
 }
 
 # --- Main ---
@@ -145,6 +206,7 @@ Options:
   --preview   Fast apply (<50ms) — structural elements only
   --full      Complete apply (~200ms) — Dracula pipeline + all elements
   --vars      Debug: print extracted palette variables
+  --darken    Darken a hex color by percentage (default 12%)
   -h, --help  Show this help message
 EOF
   exit 0
@@ -153,6 +215,12 @@ EOF
 for arg in "$@"; do
   case "$arg" in -h|--help) usage ;; esac
 done
+
+# Standalone utility mode: tmux-palette --darken <#hex> [percent]
+if [[ "${1:-}" == "--darken" ]]; then
+  _darken_hex "${2:-}" "${3:-12}"
+  exit 0
+fi
 
 preset="${1:-}"
 mode="${2:---full}"

--- a/tests/test-tmux-palette.sh
+++ b/tests/test-tmux-palette.sh
@@ -126,9 +126,9 @@ _test_full() {
     "$([[ "$pactive_bg" == "#"* ]] && echo true || echo false)"
 }
 
-_test_preview "starship-bubble-gradient-aurora-deep.toml" "#0c0620" "#00a850"
+_test_preview "starship-bubble-gradient-aurora-deep.toml" "#0c2d1e" "#44ffaa"
 _test_preview "starship-bracket-aurora.toml" "default" "#00e888"
-_test_full "starship-bubble-gradient-aurora-deep.toml" "#00a850"
+_test_full "starship-bubble-gradient-aurora-deep.toml" "#44ffaa"
 _test_full "starship-bracket-aurora.toml" "#00e888"
 
 tmux -L palette-test kill-server 2>/dev/null || true

--- a/tests/test-tmux-palette.sh
+++ b/tests/test-tmux-palette.sh
@@ -53,6 +53,21 @@ _test_extraction "starship-powerline-gradient-ocean.toml" \
 _test_extraction "starship-clean-gradient-ocean.toml" \
   "#20b8b0" "#083028" "#081828" "#081028" "#080c20" "#40e0d0" "false"
 
+echo ""
+echo "=== Darken tests ==="
+
+_test_darken() {
+  local input="$1" pct="$2" expected="$3"
+  local actual; actual=$("$PALETTE" --darken "$input" "$pct")
+  _assert "darken $input @ ${pct}%" "$expected" "$actual"
+}
+
+_test_darken "#80e0a0" 12 "#0f1a13"
+_test_darken "#ff0000" 12 "#1e0000"
+_test_darken "#000000" 12 "#000000"
+_test_darken "#ffffff" 12 "#1e1e1e"
+_test_darken "#44ffaa" 12 "#081e14"
+
 # --- Apply tests (tmux required) ---
 
 if ! $EXTRACTION_ONLY; then
@@ -61,13 +76,14 @@ echo ""
 echo "=== Apply tests (tmux) ==="
 
 tmux -L palette-test new-session -d -s test 2>/dev/null
+PALETTE_TEST_SOCKET=$(tmux -L palette-test display-message -p "#{socket_path}")
 
 _test_preview() {
   local preset="$1" e_status_bg="$2" e_border="$3"
   local label; label=$(basename "$preset" .toml | sed 's/^starship-//')
   printf '%s --preview\n' "$label"
 
-  TMUX="/tmp/tmux-palette-test/palette-test,0,0" \
+  TMUX="${PALETTE_TEST_SOCKET},0,0" \
     "$PALETTE" "$PRESETS/$preset" --preview
 
   local status; status=$(tmux -L palette-test show-option -gv status-style)
@@ -77,6 +93,15 @@ _test_preview() {
     "$([[ "$status" == *"$e_status_bg"* ]] && echo true || echo false)"
   _assert "pane-active-border contains fg" "true" \
     "$([[ "$border" == *"$e_border"* ]] && echo true || echo false)"
+  local wactive; wactive=$(tmux -L palette-test show-option -gv window-active-style)
+  local wstyle; wstyle=$(tmux -L palette-test show-option -gv window-style)
+  _assert "window-active-style has bg" "true" \
+    "$([[ "$wactive" == *"bg=#"* ]] && echo true || echo false)"
+  _assert "window-style has tinted bg" "true" \
+    "$([[ "$wstyle" == *"bg=#"* ]] && echo true || echo false)"
+  local pactive_bg; pactive_bg=$(tmux -L palette-test show-option -gqv @palette-active-bg 2>/dev/null || echo "")
+  _assert "@palette-active-bg is set" "true" \
+    "$([[ "$pactive_bg" == "#"* ]] && echo true || echo false)"
 }
 
 _test_full() {
@@ -84,12 +109,21 @@ _test_full() {
   local label; label=$(basename "$preset" .toml | sed 's/^starship-//')
   printf '%s --full\n' "$label"
 
-  TMUX="/tmp/tmux-palette-test/palette-test,0,0" \
+  TMUX="${PALETTE_TEST_SOCKET},0,0" \
     "$PALETTE" "$PRESETS/$preset" --full
 
   local colors; colors=$(tmux -L palette-test show-option -gv @dracula-colors 2>/dev/null || echo "")
   _assert "@dracula-colors contains palette" "true" \
     "$([[ "$colors" == *"$e_dracula_has"* ]] && echo true || echo false)"
+  local wactive; wactive=$(tmux -L palette-test show-option -gv window-active-style)
+  local wstyle; wstyle=$(tmux -L palette-test show-option -gv window-style)
+  _assert "window-active-style has bg" "true" \
+    "$([[ "$wactive" == *"bg=#"* ]] && echo true || echo false)"
+  _assert "window-style has tinted bg" "true" \
+    "$([[ "$wstyle" == *"bg=#"* ]] && echo true || echo false)"
+  local pactive_bg; pactive_bg=$(tmux -L palette-test show-option -gqv @palette-active-bg 2>/dev/null || echo "")
+  _assert "@palette-active-bg is set" "true" \
+    "$([[ "$pactive_bg" == "#"* ]] && echo true || echo false)"
 }
 
 _test_preview "starship-bubble-gradient-aurora-deep.toml" "#0c0620" "#00a850"

--- a/tmux.conf
+++ b/tmux.conf
@@ -23,7 +23,7 @@ bind N new-window
 set -g pane-border-style fg=red
 set -g pane-active-border-style 'fg=colour160,bg=colour214'
 set -g pane-border-status top
-set -g pane-border-format '#{?#{pane_active},#[fg=colour255]#[bg=#{@palette-c1}]#[bold],#[fg=colour245]#[bg=colour238]} #{?#{||:#{==:#{pane_title},},#{==:#{pane_title},#{host}}},#{pane_current_command},#{pane_title}} - #{pane_index} #[default]'
+set -g pane-border-format '#{?#{pane_active},#[fg=#{@palette-title-fg}]#[bg=#{@palette-c1}]#[bold],#[fg=#{@palette-pfg}]#[bg=#{@palette-inactive-bg}]} #{?#{||:#{==:#{pane_title},},#{==:#{pane_title},#{host}}},#{pane_current_command},#{pane_title}} - #{pane_index} #[default]'
 
 # Indexes of windows/panes to start at 1 (better to use Alt+NUMBER to switch to window)
 set -g base-index 1
@@ -35,8 +35,8 @@ set -g default-terminal "tmux-256color"
 set -g window-status-current-style bg=blue
 
 # transparent background
-set -g window-active-style 'bg=terminal,fg=terminal'
-set -g window-style 'bg=#2b2b2b,fg=colour246'
+set -g window-active-style 'bg=#1e1e2e,fg=terminal'
+set -g window-style 'bg=terminal,fg=terminal'
 
 set -g status-justify centre
 set -g status-left-length 50
@@ -224,7 +224,7 @@ run-shell 'cfg="$(readlink "$HOME/.config/starship/config.toml" 2>/dev/null)"; d
 run '~/.config/tmux/plugins/tpm/tpm'
 
 # Override dracula's pane borders and window list (must be after run/TPM)
-run-shell -d 1 'c1="$(tmux show-option -gqv @palette-c1)"; pfg="$(tmux show-option -gqv @palette-pfg)"; tmux set-option -g pane-active-border-style "fg=${c1:-colour117},bg=${c1:-colour117}"; tmux set-option -g pane-border-style "fg=${pfg:-colour255}"'
+run-shell -d 1 'c1="$(tmux show-option -gqv @palette-c1)"; pfg="$(tmux show-option -gqv @palette-pfg)"; abg="$(tmux show-option -gqv @palette-active-bg)"; ibg="$(tmux show-option -gqv @palette-inactive-bg)"; tmux set-option -g pane-active-border-style "fg=${c1:-colour117},bg=${c1:-colour117}"; tmux set-option -g pane-border-style "fg=${pfg:-colour255}"; tmux set-option -g window-active-style "bg=${abg:-#1e1e2e},fg=terminal"; tmux set-option -g window-style "bg=${ibg:-terminal},fg=#c0c0c0"'
 set -g window-status-current-style 'bg=default'
 set -g window-status-current-format '#[fg=#{@palette-c1}]win #[fg=default]#{window_index}/#{session_windows} #[fg=#{@palette-c1}]| #[fg=#{@palette-c1}]pane #[fg=default]#{pane_index}/#{window_panes} #[fg=#{@palette-c1}]| #[fg=default]#{?#{||:#{==:#{pane_title},},#{==:#{pane_title},#{host}}},#{pane_current_command},#{pane_title}}#{?window_zoomed_flag, #[fg=#{@palette-c1}]| #[fg=#{@palette-c2}]ZOOMED,}'
 set -g window-status-format ''


### PR DESCRIPTION
## Summary
- Inactive panes get a palette-derived background tint (pfg × 25%) with subtly muted text (`#c0c0c0`)
- Active pane uses fixed `#1e1e2e` (Catppuccin Mocha base)
- Status bar segments use a 5-step gradient from the most saturated color (auto-selected between c1 and pfg via chroma comparison)
- Contrast-safe text: auto dark/light foreground per segment luminance
- Pane title bars use palette colors instead of hardcoded grays

## Why
- Deep/glow presets had indistinguishable status bar segments (c2-c5 all near-black)
- No visual distinction between active and inactive panes
- Some presets (catppuccin) had invisible text due to dark pfg used as foreground

## Validation
- 51/51 automated tests passing
- Visual verification with screenshots across 8+ presets (twilight-deep, ocean, synthwave, forest, inferno-deep, solar-deep, dusk-deep, bracket-aurora, catppuccin)